### PR TITLE
fix: add subprocess timeouts; fix req key lockout while sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Conventional Commits](https://www.conventionalcommi
 
 <!-- Agents append entries here using: gh issue comment + docs agent -->
 
+## [Unreleased]
+
+### Fixed
+- **Subprocess calls now time out**: every external CLI call (`gh`, `npx`, the AI harnesses, `rtk`, `curl|sh`, `cargo`, `tar`, design portal, lefthook) routes through a shared `runWithTimeout` helper with a class-appropriate deadline (AI 120s, network 60s, install 300s, `gh auth status` 10s at boot). A hung child no longer blocks forever.
+- **`maple req` no longer locks out keys while sending**: the `reqStepSending` state now handles `ctrl+c`/`esc`, cancelling the in-flight AI call and exiting cleanly instead of swallowing every keypress until the terminal is killed.
+
 ## [4.17.1] — 2026-06-26
 
 ### Fixed

--- a/tui/boot.go
+++ b/tui/boot.go
@@ -54,7 +54,7 @@ func newBootModel(t Theme) *bootModel {
 }
 
 func checkGHAuth() error {
-	out, err := exec.Command("gh", "auth", "status").CombinedOutput()
+	out, err := runWithTimeout(timeoutAuth, nil, "gh", "auth", "status")
 	if err != nil {
 		msg := strings.TrimSpace(string(out))
 		if msg == "" {

--- a/tui/dashboard.go
+++ b/tui/dashboard.go
@@ -2028,8 +2028,7 @@ func (m *dashboardModel) runTestCmd(e testEntry) tea.Cmd {
 			if len(e.runCmd) == 0 {
 				return testRunDoneMsg{lines: []string{"no run command configured"}, failed: true}
 			}
-			cmd := exec.Command(e.runCmd[0], e.runCmd[1:]...)
-			out, err := cmd.CombinedOutput()
+			out, err := runWithTimeout(timeoutInstall, nil, e.runCmd[0], e.runCmd[1:]...)
 			lines := strings.Split(strings.TrimRight(string(out), "\n"), "\n")
 			if len(lines) == 0 {
 				lines = []string{"(no output)"}
@@ -2048,8 +2047,7 @@ func (m *dashboardModel) runShipSafeCmd() tea.Cmd {
 			if err != nil {
 				return shipSafeDoneMsg{lines: []string{"npx not found — install Node.js from nodejs.org"}, failed: true}
 			}
-			cmd := exec.Command(npx, "ship-safe", "audit", ".")
-			out, err := cmd.CombinedOutput()
+			out, err := runWithTimeout(timeoutNetwork, nil, npx, "ship-safe", "audit", ".")
 			lines := strings.Split(strings.TrimRight(string(out), "\n"), "\n")
 			if len(lines) == 0 {
 				lines = []string{"(no output)"}
@@ -2290,7 +2288,7 @@ func rtkInitCmd(h rtkHarness) tea.Cmd {
 		if err != nil {
 			return rtkInitDoneMsg{key: h.key, err: "rtk not found"}
 		}
-		out, err := exec.Command(rtkPath, h.flags...).CombinedOutput()
+		out, err := runWithTimeout(timeoutLocal, nil, rtkPath, h.flags...)
 		if err != nil {
 			return rtkInitDoneMsg{key: h.key, err: strings.TrimSpace(string(out))}
 		}
@@ -2304,13 +2302,13 @@ func designPortalCmd(open, auto bool, stage string, port int) tea.Cmd {
 		if _, err := os.Stat(script); err != nil {
 			return designPortalResultMsg{err: "scripts/design-review-portal.sh not found", open: open, auto: auto, stage: stage}
 		}
-		var cmd *exec.Cmd
+		var out []byte
+		var err error
 		if open {
-			cmd = exec.Command("bash", script, "open")
+			out, err = runWithTimeout(timeoutLocal, nil, "bash", script, "open")
 		} else {
-			cmd = exec.Command("bash", script, "start", strconv.Itoa(port))
+			out, err = runWithTimeout(timeoutLocal, nil, "bash", script, "start", strconv.Itoa(port))
 		}
-		out, err := cmd.CombinedOutput()
 		if err != nil {
 			msg := strings.TrimSpace(string(out))
 			if msg == "" {

--- a/tui/gh_cmds.go
+++ b/tui/gh_cmds.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 )
 
@@ -86,11 +85,11 @@ func runLabels(gh string) error {
 	for _, g := range groups {
 		fmt.Printf("\n  %s\n", g.title)
 		for _, l := range g.labels {
-			out, err := exec.Command(gh, "label", "create", l.name,
+			out, err := runWithTimeout(timeoutNetwork, nil, gh, "label", "create", l.name,
 				"--color", l.color,
 				"--description", l.desc,
 				"--force",
-			).CombinedOutput()
+			)
 			if err != nil {
 				if strings.Contains(string(out), "already exists") {
 					fmt.Printf("    ~ %s\n", l.name)
@@ -120,7 +119,7 @@ func runProject(gh string) error {
 	}
 
 	// Get repo owner/name
-	repoOut, err := exec.Command(gh, "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner").Output()
+	repoOut, err := runWithTimeout(timeoutNetwork, nil, gh, "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner")
 	if err != nil {
 		return fmt.Errorf("gh repo view: %w", err)
 	}
@@ -134,11 +133,11 @@ func runProject(gh string) error {
 	fmt.Printf("  Creating GitHub Project v2 for %s...\n", repo)
 
 	// Create project
-	projOut, err := exec.Command(gh, "project", "create",
+	projOut, err := runWithTimeout(timeoutNetwork, nil, gh, "project", "create",
 		"--owner", owner,
 		"--title", "MAPLE",
 		"--format", "json",
-	).Output()
+	)
 	if err != nil {
 		return fmt.Errorf("gh project create: %w", err)
 	}
@@ -211,7 +210,7 @@ func bootstrapProjectFields(gh, owner, number string) error {
 		if len(f.options) > 0 {
 			args = append(args, "--single-select-options", strings.Join(f.options, ","))
 		}
-		out, err := exec.Command(gh, args...).CombinedOutput()
+		out, err := runWithTimeout(timeoutNetwork, nil, gh, args...)
 		if err != nil {
 			if strings.Contains(string(out), "already exists") {
 				fmt.Printf("    ~ field %q already exists\n", f.name)

--- a/tui/init.go
+++ b/tui/init.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -299,7 +298,7 @@ func doInit(tools Tools, fsys fs.FS, force bool) ([]string, error) {
 
 	// Wire lefthook
 	if tools.Lefthook != "" {
-		if out, err := exec.Command(tools.Lefthook, "install").CombinedOutput(); err != nil {
+		if out, err := runWithTimeout(timeoutLocal, nil, tools.Lefthook, "install"); err != nil {
 			log("✗ lefthook install: " + strings.TrimSpace(string(out)))
 		} else {
 			log("✓ lefthook hooks wired")
@@ -321,19 +320,19 @@ func doInit(tools Tools, fsys fs.FS, force bool) ([]string, error) {
 	if rtkPath != "" {
 		// -g wires the hook into ~/.claude/settings.json (global, all projects).
 		// --auto-patch skips the interactive prompt. Idempotent — safe to re-run on update.
-		if out, err := exec.Command(rtkPath, "init", "-g", "--auto-patch").CombinedOutput(); err != nil {
+		if out, err := runWithTimeout(timeoutNetwork, nil, rtkPath, "init", "-g", "--auto-patch"); err != nil {
 			log("~ rtk init: " + strings.TrimSpace(string(out)))
 		} else {
 			log("✓ rtk hook wired (global ~/.claude/settings.json)")
 		}
 		// Wire OpenCode too if the plugin isn't already present.
-		if out, err := exec.Command(rtkPath, "init", "-g", "--auto-patch", "--opencode").CombinedOutput(); err != nil {
+		if out, err := runWithTimeout(timeoutNetwork, nil, rtkPath, "init", "-g", "--auto-patch", "--opencode"); err != nil {
 			log("~ rtk opencode: " + strings.TrimSpace(string(out)))
 		} else {
 			log("✓ rtk opencode plugin wired")
 		}
 		// Confirm hook status.
-		if out, err := exec.Command(rtkPath, "init", "--show").CombinedOutput(); err == nil {
+		if out, err := runWithTimeout(timeoutLocal, nil, rtkPath, "init", "--show"); err == nil {
 			for _, line := range strings.Split(string(out), "\n") {
 				if strings.Contains(line, "[ok]") || strings.Contains(line, "[warn]") || strings.Contains(line, "[--]") {
 					log("  " + strings.TrimSpace(line))

--- a/tui/loaders.go
+++ b/tui/loaders.go
@@ -118,10 +118,10 @@ func loadPRsCmd() tea.Cmd {
 		if err != nil {
 			return prsLoadedMsg{err: "gh not found"}
 		}
-		out, err := exec.Command(ghPath, "pr", "list",
+		out, err := runWithTimeout(timeoutNetwork, nil, ghPath, "pr", "list",
 			"--json", "number,title,state",
 			"--limit", "20",
-		).Output()
+		)
 		if err != nil {
 			return prsLoadedMsg{err: "gh pr list: " + strings.TrimSpace(string(out))}
 		}
@@ -147,7 +147,7 @@ func approvePRCmd(number int) tea.Cmd {
 		if err != nil {
 			return prApproveResultMsg{number: number, err: "gh not found"}
 		}
-		out, err := exec.Command(ghPath, "pr", "review", fmt.Sprintf("%d", number), "--approve").CombinedOutput()
+		out, err := runWithTimeout(timeoutNetwork, nil, ghPath, "pr", "review", fmt.Sprintf("%d", number), "--approve")
 		if err != nil {
 			msg := strings.TrimSpace(string(out))
 			// Strip verbose GraphQL prefix for readability
@@ -166,7 +166,7 @@ func loadPRDetailCmd(number int, title string) tea.Cmd {
 		if err != nil {
 			return prDetailLoadedMsg{err: "gh not found", title: title}
 		}
-		out, err := exec.Command(ghPath, "pr", "view", fmt.Sprintf("%d", number)).Output()
+		out, err := runWithTimeout(timeoutNetwork, nil, ghPath, "pr", "view", fmt.Sprintf("%d", number))
 		if err != nil {
 			return prDetailLoadedMsg{err: strings.TrimSpace(string(out)), title: title}
 		}

--- a/tui/main.go
+++ b/tui/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -344,7 +345,9 @@ func selfUpdate() error {
 
 	// Extract the maple binary from the tar and write alongside current exe
 	newBin := exe + ".new"
-	extractCmd := exec.Command("tar", "-xzf", tmp.Name(), "-O", "maple")
+	ctx, cancel := context.WithTimeout(context.Background(), timeoutInstall)
+	defer cancel()
+	extractCmd := exec.CommandContext(ctx, "tar", "-xzf", tmp.Name(), "-O", "maple")
 	newFile, err := os.OpenFile(newBin, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
 	if err != nil {
 		return err

--- a/tui/req.go
+++ b/tui/req.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -100,6 +100,7 @@ type reqModel struct {
 	storyListTop int // Y row where first story item is rendered (for mouse clicks)
 	implReturnTo reqStep
 	implCursor   int
+	cancelSend   context.CancelFunc
 }
 
 type reqDoneMsg struct {
@@ -213,6 +214,16 @@ func (m *reqModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.step = reqStepEdit
 				return m, textarea.Blink
 			case "ctrl+c", "q", "esc":
+				return m, tea.Quit
+			}
+			return m, nil
+
+		case reqStepSending:
+			switch msg.String() {
+			case "ctrl+c", "esc":
+				if m.cancelSend != nil {
+					m.cancelSend()
+				}
 				return m, tea.Quit
 			}
 			return m, nil
@@ -487,7 +498,7 @@ func (m *reqModel) sendingView(t Theme) string {
 	line2 := "  " + m.spinner.View() +
 		lipgloss.NewStyle().Foreground(t.Accent).Render(" Converting to Gherkin…") +
 		"  " + lipgloss.NewStyle().Foreground(t.Muted).Render(elapsed.String())
-	hint := lipgloss.NewStyle().Foreground(t.Muted).Render("  This may take 10–30 seconds.")
+	hint := lipgloss.NewStyle().Foreground(t.Muted).Render("  This may take 10–30 seconds.  Esc to cancel.")
 	return line1 + "\n\n" + line2 + "\n" + hint + "\n"
 }
 
@@ -691,9 +702,9 @@ Rules:
 Requirements:
 %s`
 
-func convertToGherkin(requirements string, ai aiOption) (string, error) {
+func convertToGherkin(ctx context.Context, requirements string, ai aiOption) (string, error) {
 	prompt := fmt.Sprintf(gherkinPrompt, requirements)
-	out, err := invokeAI(ai, prompt)
+	out, err := invokeAI(ctx, ai, prompt)
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", ai.label, err)
 	}
@@ -838,26 +849,27 @@ func (m *reqModel) launchImplementationCmd(ai aiOption) tea.Cmd {
 // invokeAI runs the selected AI tool and returns its stdout output.
 // The prompt is passed as a positional argument (not stdin) to avoid inheriting
 // the Bubble Tea raw-mode terminal state in the subprocess.
-func invokeAI(ai aiOption, prompt string) ([]byte, error) {
-	var cmd *exec.Cmd
+func invokeAI(ctx context.Context, ai aiOption, prompt string) ([]byte, error) {
+	var (
+		out []byte
+		err error
+	)
 	switch ai.kind {
 	case "claude":
 		// -p = --print (non-interactive), prompt is positional arg.
 		// --output-format text suppresses JSON wrappers.
 		// --no-session-persistence avoids writing session files.
-		cmd = exec.Command(ai.path, "-p", "--output-format", "text", "--no-session-persistence", prompt)
+		out, err = runCtx(ctx, timeoutAI, nil, "", ai.path, "-p", "--output-format", "text", "--no-session-persistence", prompt)
 	case "copilot":
-		cmd = exec.Command(ai.path, "-i", prompt)
+		out, err = runCtx(ctx, timeoutAI, nil, "", ai.path, "-i", prompt)
 	case "opencode":
-		cmd = exec.Command(ai.path, "run")
-		cmd.Stdin = strings.NewReader(prompt)
+		out, err = runCtx(ctx, timeoutAI, nil, prompt, ai.path, "run")
 	case "cursor":
-		return invokeCursor(ai.path, prompt)
+		return invokeCursor(ctx, ai.path, prompt)
 	default:
 		return nil, fmt.Errorf("unsupported AI tool: %s", ai.kind)
 	}
 
-	out, err := cmd.CombinedOutput()
 	if err != nil {
 		msg := strings.TrimSpace(string(out))
 		if msg == "" {
@@ -868,20 +880,22 @@ func invokeAI(ai aiOption, prompt string) ([]byte, error) {
 	return out, nil
 }
 
-func invokeCursor(binPath, prompt string) ([]byte, error) {
-	candidates := []*exec.Cmd{
-		exec.Command(binPath, "-p", "--output-format", "text", "--trust", prompt),
-		exec.Command(binPath, "-p", prompt),
-		exec.Command(binPath, "--prompt", prompt),
-		exec.Command(binPath, "run", prompt),
+func invokeCursor(ctx context.Context, binPath, prompt string) ([]byte, error) {
+	type attempt struct {
+		args  []string
+		stdin string
 	}
-	stdinRun := exec.Command(binPath, "run")
-	stdinRun.Stdin = strings.NewReader(prompt)
-	candidates = append(candidates, stdinRun)
+	candidates := []attempt{
+		{args: []string{"-p", "--output-format", "text", "--trust", prompt}},
+		{args: []string{"-p", prompt}},
+		{args: []string{"--prompt", prompt}},
+		{args: []string{"run", prompt}},
+		{args: []string{"run"}, stdin: prompt},
+	}
 
 	var lastErr string
-	for _, cmd := range candidates {
-		out, err := cmd.CombinedOutput()
+	for _, c := range candidates {
+		out, err := runCtx(ctx, timeoutAI, nil, c.stdin, binPath, c.args...)
 		if err == nil {
 			return out, nil
 		}
@@ -906,12 +920,15 @@ func (m *reqModel) convert(requirements string) tea.Cmd {
 			oldDirs = append(oldDirs, s.savedTo)
 		}
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	m.cancelSend = cancel
 	return func() tea.Msg {
+		defer cancel()
 		// remove old story directories before saving new ones
 		for _, d := range oldDirs {
 			_ = os.RemoveAll(d)
 		}
-		gherkin, err := convertToGherkin(requirements, ai)
+		gherkin, err := convertToGherkin(ctx, requirements, ai)
 		if err != nil {
 			return reqDoneMsg{err: err}
 		}

--- a/tui/rtk_install.go
+++ b/tui/rtk_install.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -116,10 +117,15 @@ func installRTKFromUpstreamScript() (string, error) {
 		return "", fmt.Errorf("upstream install script is linux/macos only")
 	}
 
-	cmd := exec.Command("sh", "-c", "curl -fsSL "+rtkUpstreamInstallURL+" | sh")
+	ctx, cancel := context.WithTimeout(context.Background(), timeoutInstall)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "sh", "-c", "curl -fsSL "+rtkUpstreamInstallURL+" | sh")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("upstream install script timed out after %s", timeoutInstall)
+		}
 		return "", fmt.Errorf("upstream install script failed: %w", err)
 	}
 	return findInstalledRTK()
@@ -134,10 +140,15 @@ func installRTKFromCargo() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("cargo not found on PATH")
 	}
-	cmd := exec.Command(cargo, "install", "--git", "https://github.com/rtk-ai/rtk", "--quiet")
+	ctx, cancel := context.WithTimeout(context.Background(), timeoutInstall)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, cargo, "install", "--git", "https://github.com/rtk-ai/rtk", "--quiet")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("cargo install timed out after %s", timeoutInstall)
+		}
 		return "", fmt.Errorf("cargo install failed: %w", err)
 	}
 	return findInstalledRTK()

--- a/tui/skills.go
+++ b/tui/skills.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -58,7 +59,9 @@ func searchSkillsCmd(query string) tea.Cmd {
 		if query != "" {
 			args = append(args, query)
 		}
-		cmd := exec.Command("npx", args...)
+		ctx, cancel := context.WithTimeout(context.Background(), timeoutNetwork)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "npx", args...)
 		// npm_config_yes=true auto-confirms package install without needing package.json.
 		// NO_COLOR/FORCE_COLOR strip ANSI so parseSkillsOutput gets clean ASCII.
 		cmd.Env = append(os.Environ(), "NO_COLOR=1", "FORCE_COLOR=0", "npm_config_yes=true")
@@ -89,11 +92,13 @@ func listInstalledSkillsCmd() tea.Cmd {
 			if scope.flag != "" {
 				args = append(args, scope.flag)
 			}
-			cmd := exec.Command("npx", args...)
+			ctx, cancel := context.WithTimeout(context.Background(), timeoutNetwork)
+			cmd := exec.CommandContext(ctx, "npx", args...)
 			cmd.Env = append(os.Environ(), "NO_COLOR=1", "FORCE_COLOR=0", "npm_config_yes=true")
 			var stdout bytes.Buffer
 			cmd.Stdout = &stdout
 			_ = cmd.Run()
+			cancel()
 
 			items := parseInstalledJSON(stdout.String(), scope.label)
 			if len(items) == 0 {
@@ -108,9 +113,8 @@ func listInstalledSkillsCmd() tea.Cmd {
 
 func removeSkillCmd(name string) tea.Cmd {
 	return func() tea.Msg {
-		cmd := exec.Command("npx", "skills", "remove", name, "--all", "-y")
-		cmd.Env = append(os.Environ(), "NO_COLOR=1", "FORCE_COLOR=0", "npm_config_yes=true")
-		out, err := cmd.CombinedOutput()
+		env := append(os.Environ(), "NO_COLOR=1", "FORCE_COLOR=0", "npm_config_yes=true")
+		out, err := runWithTimeout(timeoutNetwork, env, "npx", "skills", "remove", name, "--all", "-y")
 		if err != nil {
 			msg := strings.TrimSpace(stripANSI(string(out)))
 			if msg == "" {
@@ -192,9 +196,8 @@ func parseInstalledText(s, scope string) []installedSkillRow {
 
 func installSkillCmd(pkg string) tea.Cmd {
 	return func() tea.Msg {
-		cmd := exec.Command("npx", "skills", "add", pkg, "--all", "-y")
-		cmd.Env = append(os.Environ(), "NO_COLOR=1", "FORCE_COLOR=0", "npm_config_yes=true")
-		out, err := cmd.CombinedOutput()
+		env := append(os.Environ(), "NO_COLOR=1", "FORCE_COLOR=0", "npm_config_yes=true")
+		out, err := runWithTimeout(timeoutNetwork, env, "npx", "skills", "add", pkg, "--all", "-y")
 		if err != nil {
 			msg := strings.TrimSpace(stripANSI(string(out)))
 			if msg == "" {

--- a/tui/subprocess.go
+++ b/tui/subprocess.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Default timeouts by call class.
+const (
+	timeoutAI      = 120 * time.Second // AI harness calls (req)
+	timeoutNetwork = 60 * time.Second  // gh / npx network calls
+	timeoutInstall = 300 * time.Second // curl|sh, cargo install, tar extract
+	timeoutAuth    = 10 * time.Second  // gh auth status at boot — fail fast
+	timeoutLocal   = 30 * time.Second  // local helpers (lefthook, rtk init, portal)
+)
+
+// runWithTimeout runs name+args with a deadline, returning combined output.
+// On timeout it kills the child and returns an error callers can surface as
+// "timed out — check auth / network".
+func runWithTimeout(d time.Duration, env []string, name string, args ...string) ([]byte, error) {
+	return runWithTimeoutStdin(d, env, "", name, args...)
+}
+
+// runWithTimeoutStdin is runWithTimeout with a string fed to the child's stdin.
+func runWithTimeoutStdin(d time.Duration, env []string, stdin, name string, args ...string) ([]byte, error) {
+	return runCtx(context.Background(), d, env, stdin, name, args...)
+}
+
+// runCtx runs name+args under parent+deadline. Cancelling parent kills the child;
+// a deadline hit is reported as a timeout error. Either path frees the process.
+func runCtx(parent context.Context, d time.Duration, env []string, stdin, name string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(parent, d)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	if env != nil {
+		cmd.Env = env
+	}
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return out, fmt.Errorf("%s timed out after %s — check auth / network", name, d)
+	}
+	return out, err
+}

--- a/tui/subprocess_test.go
+++ b/tui/subprocess_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunWithTimeout_Success(t *testing.T) {
+	out, err := runWithTimeout(timeoutLocal, nil, "echo", "hello")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "hello" {
+		t.Errorf("got %q, want hello", out)
+	}
+}
+
+func TestRunWithTimeout_TimesOut(t *testing.T) {
+	start := time.Now()
+	_, err := runWithTimeout(100*time.Millisecond, nil, "sleep", "5")
+	if err == nil {
+		t.Fatal("expected a timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("error should mention timeout, got: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("timeout did not kill child promptly: took %s", elapsed)
+	}
+}
+
+func TestRunWithTimeout_NonZeroExit(t *testing.T) {
+	_, err := runWithTimeout(timeoutLocal, nil, "sh", "-c", "exit 3")
+	if err == nil {
+		t.Fatal("expected error for non-zero exit")
+	}
+	if strings.Contains(err.Error(), "timed out") {
+		t.Errorf("non-zero exit misreported as timeout: %v", err)
+	}
+}
+
+func TestRunWithTimeoutStdin_FeedsStdin(t *testing.T) {
+	out, err := runWithTimeoutStdin(timeoutLocal, nil, "from-stdin\n", "cat")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "from-stdin" {
+		t.Errorf("got %q, want from-stdin", out)
+	}
+}


### PR DESCRIPTION
## What is this PR doing?

Wraps every external-CLI call in the TUI with a timeout, and fixes a `maple req` key lockout where a hung send swallowed `Ctrl+C`.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Spike

## Story / Issue

No linked issue — surfaced by an audit of every `exec.Command` call site. Happy to file one if preferred.

---

## The problem

MAPLE shells out to external CLIs (`gh`, `npx`, the AI harnesses, `rtk`, `curl`, `cargo`, `tar`, `bash` scripts) all over the TUI. Two recurring flaws, first noticed in `maple req`:

- **No timeout.** Not a single call site used `context.WithTimeout` / `exec.CommandContext`. Every `.Run()` / `.Output()` / `.CombinedOutput()` blocked **forever** if the child hung — an auth prompt on a TTY, a network stall, a stdin wait.
- **Key lockout in `req`.** The key switch had no `reqStepSending` case and no default, so **every** keypress — including `Ctrl+C` — was swallowed while a send was in flight. Killing the terminal was the only escape.

## The fix

**1. One shared timeout-aware runner** (`tui/subprocess.go`) — `runWithTimeout` / `runWithTimeoutStdin` / `runCtx` wrap `exec.CommandContext`. On timeout the child is killed and the caller gets a clear `"… timed out after … — check auth / network"` error. Class-default timeouts:

| Class | Timeout | Calls |
|---|---|---|
| AI harness | 120s | `req` (claude/copilot/opencode/cursor) |
| Network | 60s | `gh`, `npx` |
| Install | 300s | `curl \| sh`, `cargo install`, `tar`, test runner |
| Auth | 10s | `gh auth status` at boot (fast-fail so a stall can't block startup) |
| Local | 30s | lefthook, rtk init, design portal |

**2. `maple req` key lockout** — `invokeAI` / `invokeCursor` route through the helper with a cancellable `context` threaded `convert → convertToGherkin → invokeAI`. New `reqStepSending` key case: `Ctrl+C` / `Esc` cancels the in-flight call and exits cleanly; loading hint reads "Esc to cancel."

**3. Swept remaining call sites** — dashboard `tea.Cmd` sites (ship-safe, skills find/ls/add/remove, `gh pr` list/review/view, rtk init, design portal, test runner) and sync CLI paths (boot `gh auth status`, `gh` label/repo/project/field, `tar` self-update, rtk `curl|sh` + cargo install kept streaming via `CommandContext`, init lefthook + rtk init).

Left untouched on purpose: local/fast or fire-and-forget calls — `sqlite3` reads, `git status`/`diff`, clipboard, and all `terminal_spawn.go` launchers (`.Start()` by design, per the "harness launching never blocks / never exits" invariant).

## Checklist

- [x] Tests added or updated — 4 new `runWithTimeout` tests (success, timeout-kills-promptly, non-zero-exit-not-misreported, stdin feed)
- [x] All existing tests pass — `bash tests/run_all.sh` green; `go build` + `go vet` clean; 61 Go tests pass
- [ ] SDLC gates green — N/A (no story artifacts in this PR)
- [ ] DoD checklist complete in linked Issue — N/A (no linked issue)
- [ ] ADRs linked if required — N/A
- [x] No secrets committed
