### PR TITLE
Cross-harness version/issue/milestone/project tracking rule

### DIFF
--- a/docs/specs/2026-07-03-cross-harness-issue-tracking.md
+++ b/docs/specs/2026-07-03-cross-harness-issue-tracking.md
@@ -88,6 +88,12 @@ overwrites it (menu.go:274), so those old configs persist. Verified safe:
 
 ## Config schema change
 
+Reconciled with Heimdall's fix commit (f4ea31f): **drop the `labels` config key**
+(the `type:*` taxonomy is a fixed convention in `gh-labels-milestones`, not user
+config — this removes the mapping-drift risk at the root). **Keep
+`milestone_granularity` in config** (MAPLE's interactive/configurable requirement,
+which Heimdall dropped) and add it to the schema properly.
+
 `template/project.config.yaml` — extend the `github:` block:
 
 ```yaml
@@ -95,19 +101,18 @@ github:
   project_number: null          # null = ask once; 0 = declined; N = configured board
   project_node_id: null
   status_field_id: null         # cached Status single-select field id for gh-projects
-  labels:
-    fix: type:bug               # patch / bugfix
-    feature: type:feature       # minor / major (feat:)
   milestone_granularity: null   # null = ask once; none = declined; minor = major+minor (default when enabled); patch = also per-patch
+  # Issue label taxonomy (type:bug | type:feature | type:docs | type:refactor |
+  # type:chore) lives in the gh-labels-milestones skill, not here.
 ```
 
 `template/.claude/schemas/project.config.schema.json` — under `properties.github.properties`, keep `additionalProperties: false` but add:
 
-- `status_field_id`: `{ "type": ["string","null"], "default": null }`
-- `labels`: object, `additionalProperties: false`, properties `fix` and `feature`
-  (both `string`), defaults `type:bug` / `type:feature`.
-- `milestone_granularity`: `{ "type": ["string","null"], "enum": [null,"none","minor","patch"], "default": null }`
+- `status_field_id`: `{ "type": ["string","null"], "default": null }` (matches Heimdall).
+- `milestone_granularity`: `{ "type": ["string","null"], "enum": [null,"none","minor","patch"], "default": null }` (MAPLE-only).
 - `project_number`: change to allow the `0` sentinel — `{ "type": ["integer","null"], "minimum": 0, "default": null }`.
+- **No `labels` property** — dropped by design.
+- Keep the schema's existing single-line enum style; add only the new properties (surgical diff).
 
 ## The standing rule (identical intent, harness-appropriate phrasing)
 
@@ -125,9 +130,11 @@ Section title: **"Version & Issue Tracking (mandatory)"**. Body:
    - `minor` → ensure `vX.Y.0` exists (create via `gh-labels-milestones`);
      patches attach to their minor's `vX.Y.0`.
    - `patch` → patches also get milestones.
-4. **Issue — every change.** Create via `gh-issues`, labelled from
-   `github.labels` (`type:bug` for fix/patch, `type:feature` for feature/
-   minor/major), assigned to the target milestone if milestones are enabled.
+4. **Issue — every change.** Create via `gh-issues`, labelled with the matching
+   `type:*` label per `gh-labels-milestones` (`type:bug` fix · `type:feature`
+   feature · `type:docs`/`type:refactor`/`type:chore`), assigned to the target
+   milestone if milestones are enabled. The taxonomy is the skill's convention,
+   not a config mapping.
 5. **Project board.** Read `github.project_number`.
    - `null` → ask once: "Add issues to a GitHub project board?" If yes, bootstrap
      (`maple project bootstrap` / `gh-projects`) and write `project_number` +
@@ -166,13 +173,16 @@ Config + schema (2):
 - `template/project.config.yaml`
 - `template/.claude/schemas/project.config.schema.json`
 
-Skills — config-read + ask/persist + `type:*` labels + `In Progress` casing,
-each in 3 mirror copies (9 files):
-- `gh-issues/SKILL.md` — read `github.labels`; attach milestone when enabled.
-- `gh-labels-milestones/SKILL.md` — honour `milestone_granularity`; ask/persist
-  helper documented.
+Skills — `type:*` taxonomy + ask/persist + `In Progress` casing, each in 3 mirror
+copies (9 files):
+- `gh-issues/SKILL.md` — label with the `type:*` taxonomy convention; attach the
+  target milestone when milestones are enabled.
+- `gh-labels-milestones/SKILL.md` — honour `milestone_granularity`
+  (null→ask→persist `minor`/`none`); document the ask/persist helper. The `type:*`
+  taxonomy already lives here — this is the single source of truth for labels.
 - `gh-projects/SKILL.md` — `project_number` null→ask→persist; `0` sentinel skip;
-  fix any `In progress` casing.
+  cache `status_field_id`; keep `In Progress` (capital P) — MAPLE keeps capital,
+  unlike Heimdall's fix which unified on lowercase.
 - Copies under `.claude/skills/`, `.opencode/skills/`, `.cursor/skills/`.
 
 Orchestrator agent (3 mirror copies):

--- a/docs/specs/2026-07-03-cross-harness-issue-tracking.md
+++ b/docs/specs/2026-07-03-cross-harness-issue-tracking.md
@@ -82,9 +82,15 @@ overwrites it (menu.go:274), so those old configs persist. Verified safe:
   comment after `null` keeps that substring intact, so the replace still fires.
   It does NOT currently write `status_field_id` or `milestone_granularity` — the
   skills cache/populate those (binary extension is a nice-to-have, not required).
-- **Verify:** `maple update` also re-syncs the root harness md files + `.github/`
-  so existing users actually receive the new rule text (check the init.go copy
-  list; if root md/.github are not in it, note the gap).
+- **Verify:** `maple update` re-syncs the surfaces that carry the rule. **Finding
+  (init.go:245-270):** the copy list includes `.github`, `.cursor`, `.claude` +
+  `CLAUDE.md`, and `.opencode` + `AGENTS.md` — but NOT the root `OPENCODE.md`,
+  `CURSOR.md`, or `COPILOT.md`. Those three root files are never installed
+  (pre-existing gap). The rule still reaches every harness via an installed
+  surface: Claude → `CLAUDE.md`; OpenCode → `AGENTS.md` + `.opencode` orchestrator;
+  Cursor → `.cursor/rules/version-and-issues.mdc`; Copilot →
+  `.github/copilot-instructions.md`. Optional follow-up: add the three root md
+  files to the init.go copy list so `req.go`'s referenced roots actually ship.
 
 ## Config schema change
 

--- a/docs/specs/2026-07-03-cross-harness-issue-tracking.md
+++ b/docs/specs/2026-07-03-cross-harness-issue-tracking.md
@@ -1,0 +1,228 @@
+# Design — Cross-harness version / issue / milestone / project tracking
+
+Date: 2026-07-03
+Repo: MAPLE (`template/` tree — what `maple init` copies into user projects)
+Reference: Heimdall PR #131 (initial rule) + PR #153 (orchestrator follow-up), with
+every review finding from both pre-fixed.
+
+## Goal
+
+Make every change a MAPLE-initialised project works on tracked the same way, in
+every harness (Claude, OpenCode, Copilot, Cursor):
+
+1. If a GitHub repo is set up → the change gets a **GitHub issue** labelled
+   `type:bug` / `type:feature`.
+2. **Milestones** exist for **major & minor only** (`vX.Y.0`); patches attach to
+   their minor's milestone, never their own — unless the user opts into per-patch.
+3. The issue lands on the **configured project board** with a **Status**
+   (`In Progress` → `Done`).
+4. All of it is driven by `project.config.yaml → github`, never hard-coded.
+5. When milestones or a board are **not configured**, the agent **asks the user
+   once** and persists the answer so it never re-asks.
+
+This is the MAPLE port of Heimdall PR #131 with every review finding from that PR
+fixed up front, plus the interactive bootstrap (Heimdall's config was pre-filled;
+MAPLE ships `null`s).
+
+## Non-goals
+
+- No new `maple` subcommand. `maple project bootstrap` / `maple labels` already
+  exist; the rule points at them and at the existing skills.
+- No change to the SemVer scheme itself — the project may override it in
+  `project.config.yaml`; the rule reads whatever is configured.
+- No backfill of issues for past work.
+
+## Decisions (locked with the user)
+
+| Decision | Choice |
+|---|---|
+| Enforcement scope | **Docs + skills + orchestrator** — standing rule in all instruction surfaces, the 3 `gh-*` skills read the new config and drive check→ask→persist, and the orchestrator runs the check at pipeline start. |
+| "Declined" state | **Sentinel values in `project.config.yaml`** (`milestone_granularity: none`, `project_number: 0`). `null` = not yet asked; sentinel = asked and declined, never re-ask. |
+| Labels | `type:bug` / `type:feature` — the labels `gh-labels-milestones` actually bootstraps. Never `bug`/`enhancement`. |
+| Status casing | `In Progress` (capital P) → `Done` — matches `gh-projects` single-select option names (`Todo` / `In Progress` / `In Review` / `Done`). |
+
+## Correctness constraints (Heimdall #131 review findings — all pre-fixed)
+
+1. **Schema.** `.claude/schemas/project.config.schema.json` sets
+   `github.additionalProperties: false` and only allows `project_number` +
+   `project_node_id`. The new keys (`status_field_id`, `labels`,
+   `milestone_granularity`) MUST be added to the schema or config validation /
+   IDE tooling rejects the file.
+2. **Labels.** Docs/config saying `bug`/`enhancement` cause automation to create
+   ad-hoc labels or fail. Use `type:bug`/`type:feature` everywhere, and keep the
+   inline config comment in sync.
+3. **Status casing.** `In progress` (lowercase p) will not match the Projects v2
+   single-select option and the update silently no-ops. Use `In Progress`.
+4. **Identical heading & wording (PR #153).** Every surface uses the exact same
+   heading "Version & Issue Tracking (mandatory)" and the same patch/milestone
+   definition. In the orchestrator agent, slot it into the existing
+   `## GitHub Issue Management` section — do not invent a divergent subsection
+   title. Divergent wording across harnesses is itself a defect.
+
+## Backwards compatibility (must-not-crash)
+
+Existing MAPLE projects already have a `project.config.yaml` WITHOUT the new keys.
+`maple init` skips an existing config (init.go:296) and `maple update` never
+overwrites it (menu.go:274), so those old configs persist. Verified safe:
+
+- **No strict yaml decode anywhere.** The binary reads config line-by-line
+  (`loadProjectName` in loaders.go; `maple project bootstrap` uses string-replace
+  in gh_cmds.go). Unknown/new keys never crash it, and a config missing the new
+  keys never crashes it either.
+- **Skills/rule must treat a missing key exactly like `null`** — i.e. ask (or use
+  the documented default), never assume the key is present. This is the core
+  compat requirement: a project inited before this change has no `labels:`,
+  `milestone_granularity:`, or `status_field_id:` at all.
+- **JSON schema is IDE-only** (`# yaml-language-server: $schema=…`), not runtime.
+  New keys are optional with defaults, so an old config still validates against
+  the widened schema. `maple update` re-copies the whole `.claude/` tree
+  (init.go:260), so existing projects receive the widened schema on update.
+- **`maple project bootstrap` string-replace stays compatible.** It replaces the
+  literal `project_number: null` / `project_node_id: null`. Adding an inline
+  comment after `null` keeps that substring intact, so the replace still fires.
+  It does NOT currently write `status_field_id` or `milestone_granularity` — the
+  skills cache/populate those (binary extension is a nice-to-have, not required).
+- **Verify:** `maple update` also re-syncs the root harness md files + `.github/`
+  so existing users actually receive the new rule text (check the init.go copy
+  list; if root md/.github are not in it, note the gap).
+
+## Config schema change
+
+`template/project.config.yaml` — extend the `github:` block:
+
+```yaml
+github:
+  project_number: null          # null = ask once; 0 = declined; N = configured board
+  project_node_id: null
+  status_field_id: null         # cached Status single-select field id for gh-projects
+  labels:
+    fix: type:bug               # patch / bugfix
+    feature: type:feature       # minor / major (feat:)
+  milestone_granularity: null   # null = ask once; none = declined; minor = major+minor (default when enabled); patch = also per-patch
+```
+
+`template/.claude/schemas/project.config.schema.json` — under `properties.github.properties`, keep `additionalProperties: false` but add:
+
+- `status_field_id`: `{ "type": ["string","null"], "default": null }`
+- `labels`: object, `additionalProperties: false`, properties `fix` and `feature`
+  (both `string`), defaults `type:bug` / `type:feature`.
+- `milestone_granularity`: `{ "type": ["string","null"], "enum": [null,"none","minor","patch"], "default": null }`
+- `project_number`: change to allow the `0` sentinel — `{ "type": ["integer","null"], "minimum": 0, "default": null }`.
+
+## The standing rule (identical intent, harness-appropriate phrasing)
+
+Section title: **"Version & Issue Tracking (mandatory)"**. Body:
+
+1. **Gate on a GitHub repo.** If `project.repo` is empty and there is no
+   `git remote`, skip everything silently.
+2. **Classify the SemVer bump** — major (breaking) / minor (new
+   backward-compatible feature) / patch (fix, no API change), per the scheme in
+   `project.config.yaml`.
+3. **Milestone — major & minor only.** Read `github.milestone_granularity`.
+   - `null` → ask the user once: "Track milestones for this project?" Persist
+     `minor` (yes) or `none` (no).
+   - `none` → skip milestones.
+   - `minor` → ensure `vX.Y.0` exists (create via `gh-labels-milestones`);
+     patches attach to their minor's `vX.Y.0`.
+   - `patch` → patches also get milestones.
+4. **Issue — every change.** Create via `gh-issues`, labelled from
+   `github.labels` (`type:bug` for fix/patch, `type:feature` for feature/
+   minor/major), assigned to the target milestone if milestones are enabled.
+5. **Project board.** Read `github.project_number`.
+   - `null` → ask once: "Add issues to a GitHub project board?" If yes, bootstrap
+     (`maple project bootstrap` / `gh-projects`) and write `project_number` +
+     `project_node_id` + `status_field_id` back to config. If no, persist `0`.
+   - `0` → skip the board.
+   - `> 0` → add the issue and set Status `In Progress` while working, `Done`
+     when shipped. Field name `Status`; option names exactly `Todo` /
+     `In Progress` / `In Review` / `Done`.
+6. **Link & close.** PR references the issue (`Closes #N`). On release the
+   milestone version equals the release tag. **No Claude/Anthropic attribution**
+   anywhere — commits, PR bodies, issues, releases.
+7. Mechanics live in the maple skills — use them, don't hand-roll:
+   `gh-labels-milestones`, `gh-issues`, `gh-projects`. Config lives in
+   `project.config.yaml → github`.
+
+## File surface
+
+Mirror trees `.opencode/` and `.cursor/` are **real copies, not symlinks**
+(`maple init` copies each tree). Every skill/agent edit applies to all three.
+
+Standing-rule docs (7) — identical "Version & Issue Tracking (mandatory)" section,
+harness-appropriate phrasing, same heading/patch definition everywhere:
+- `template/CLAUDE.md` — upgrade pipeline rule #7, add the section.
+- `template/OPENCODE.md`
+- `template/CURSOR.md`   (root harness md — keep in parity, per harness-doc-parity)
+- `template/COPILOT.md`  (root harness md — keep in parity)
+- `template/AGENTS.md`
+- `template/.github/copilot-instructions.md`
+- `template/.cursor/rules/version-and-issues.mdc` (new, `alwaysApply: true`).
+
+The four root files CLAUDE/OPENCODE/CURSOR/COPILOT must stay byte-parallel in this
+section (harness-doc-parity rule). COPILOT.md and CURSOR.md are separate from
+`.github/copilot-instructions.md` and `.cursor/rules/`; all get the rule.
+
+Config + schema (2):
+- `template/project.config.yaml`
+- `template/.claude/schemas/project.config.schema.json`
+
+Skills — config-read + ask/persist + `type:*` labels + `In Progress` casing,
+each in 3 mirror copies (9 files):
+- `gh-issues/SKILL.md` — read `github.labels`; attach milestone when enabled.
+- `gh-labels-milestones/SKILL.md` — honour `milestone_granularity`; ask/persist
+  helper documented.
+- `gh-projects/SKILL.md` — `project_number` null→ask→persist; `0` sentinel skip;
+  fix any `In progress` casing.
+- Copies under `.claude/skills/`, `.opencode/skills/`, `.cursor/skills/`.
+
+Orchestrator agent (3 mirror copies):
+- `.claude/agents/orchestrator.md`, `.opencode/agents/orchestrator.md`,
+  `.cursor/agents/orchestrator.md` — add the check under the EXISTING
+  `## GitHub Issue Management` section (PR #153 precedent), using the identical
+  "Version & Issue Tracking" heading/wording, pointing at the rule + skills.
+
+Maple binary (verify, likely no change):
+- `tui/gh_cmds.go`, `tui/init.go` — confirm any config read/write preserves the
+  new `github` keys. Go yaml ignores unknown keys on read; a write-back must not
+  drop them. Build check per CLAUDE.md (`make build-tui`).
+
+Repo docs (MAPLE's own CLAUDE.md at repo root):
+- Note the new config keys in the Shared State / config section if relevant.
+
+## Dogfooding
+
+This change itself is a MAPLE `enhancement`. Per MAPLE's own rules it should get
+a GitHub issue on the `kinncj/MAPLE` repo, `enhancement` label, `v4.10.0`
+milestone, and a card on project 67. Handle in the implementation phase.
+
+Note the label distinction: the **MAPLE repo itself** uses `bug`/`enhancement`
+(its own CLAUDE.md convention) — that is what this dogfood issue uses. The
+**template** we ship to users uses `type:bug`/`type:feature` (what
+`gh-labels-milestones` bootstraps). These are two different repos with two label
+sets; not a contradiction.
+
+## Testing / verification
+
+- `make build-tui` green after any `tui/` touch.
+- Validate the new `project.config.yaml` against the updated schema (no
+  `additionalProperties` violation), AND validate a pre-change config (missing all
+  new keys) against the new schema — both must pass (backwards compat).
+- Grep the whole `template/` tree for stray `In progress` (lowercase) and
+  `bug`/`enhancement` label literals in the new content — must be zero.
+- Confirm the skill mirror copies stay byte-identical after edits
+  (`diff -q` across `.claude`/`.opencode`/`.cursor` for each of the 3 skills and
+  the orchestrator agent).
+- Confirm the four root harness md files carry the identical rule section
+  (harness-doc-parity).
+- Smoke: with a config that has no new keys, the rule/skill path must ask (not
+  error). With `milestone_granularity: none` / `project_number: 0`, it must skip
+  silently without re-asking.
+
+## Rollout order
+
+1. Schema + config (foundation everything else references).
+2. Skills (mechanics) × 3 copies.
+3. Standing-rule docs × 7.
+4. Orchestrator agent × 3 copies.
+5. Binary verification + build.
+6. Parity grep + schema validation.

--- a/template/.claude/agents/orchestrator.md
+++ b/template/.claude/agents/orchestrator.md
@@ -262,7 +262,15 @@ If failure → return to Phase 5.
 On success: Create PR via gh pr create, post completion summary.
 
 ## GitHub Issue Management
-Every feature has a corresponding GitHub issue. Update issues at each phase transition:
+
+### Version & Issue Tracking (mandatory — every change)
+Gate on a GitHub repo first (`project.repo` or a git remote); if none, skip this. Then classify the SemVer bump — **major** (breaking) / **minor** (new backward-compatible feature) / **patch** (bug fix, no API change) — and:
+- **Milestone — major & minor only.** Read `github.milestone_granularity` (absent = `null`). `null` → ask the user once, persist `minor` (yes) / `none` (no). `minor` → ensure `vX.Y.0` exists (`gh-labels-milestones`); a patch attaches to its minor's `vX.Y.0`, never its own. `patch` → patches get their own. `none` → skip.
+- **Issue — every change.** Labelled the matching **`type:*`** label (`type:bug` fix · `type:feature` feature · `type:docs`/`type:refactor`/`type:chore`, per `gh-labels-milestones`), assigned to the target major/minor milestone (`gh-issues`). Never `bug`/`enhancement`.
+- **Project board.** Read `github.project_number` (absent = `null`). `null` → ask once; if yes bootstrap (`maple project` / `gh-projects`) and write it back to config, if no persist `0`. `0` → skip. `> 0` → add the issue and set **Status** (`In Progress` → `Done`), reading the number from `project.config.yaml`, never hard-coded.
+- PR `Closes #N`. **No Claude/Anthropic attribution** anywhere.
+
+Every change has a corresponding GitHub issue. Update issues at each phase transition:
 
 ```bash
 # Create issue (done by @product-owner, but you track)

--- a/template/.claude/schemas/project.config.schema.json
+++ b/template/.claude/schemas/project.config.schema.json
@@ -18,6 +18,11 @@
           "description": "Human-readable project name.",
           "minLength": 1
         },
+        "created_at": {
+          "type": "string",
+          "description": "RFC3339 timestamp stamped by `maple init` when the project was scaffolded.",
+          "format": "date-time"
+        },
         "repo": {
           "type": "string",
           "description": "GitHub repository in owner/repo format.",
@@ -90,6 +95,29 @@
         }
       }
     },
+    "stack": {
+      "type": "object",
+      "description": "Tech stack. Filled by the orchestrator during discovery; all fields null until interviewed.",
+      "additionalProperties": false,
+      "properties": {
+        "frontend": { "type": ["string", "null"], "description": "react | vue | angular | nextjs | svelte | vanilla | none", "default": null },
+        "backend": { "type": ["string", "null"], "description": "nodejs | fastapi | django | spring | dotnet | none", "default": null },
+        "language": { "type": ["string", "null"], "description": "typescript | javascript | python | java | csharp | go | rust", "default": null },
+        "database": { "type": ["string", "null"], "description": "postgresql | mysql | sqlite | mongodb | supabase | none", "default": null },
+        "cache": { "type": ["string", "null"], "description": "redis | none", "default": null },
+        "css": { "type": ["string", "null"], "description": "tailwind | mantine | shadcn | bootstrap | css-modules | none", "default": null },
+        "testing": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "unit": { "type": ["string", "null"], "description": "vitest | jest | pytest | junit | nunit", "default": null },
+            "e2e": { "type": ["string", "null"], "description": "playwright | cypress | selenium | none", "default": null }
+          }
+        },
+        "deployment": { "type": ["string", "null"], "description": "vercel | aws | gcp | azure | docker | none", "default": null },
+        "package_manager": { "type": ["string", "null"], "description": "npm | pnpm | yarn | pip | maven | gradle", "default": null }
+      }
+    },
     "design": {
       "type": "object",
       "description": "Design system and UX settings.",
@@ -146,6 +174,23 @@
           "description": "Which SemVer classes get their own milestone. null = ask the user once; none = declined (no milestones); minor = major & minor only (vX.Y.0), patches attach to their minor; patch = also give patches their own milestone.",
           "enum": [null, "none", "minor", "patch"],
           "default": null
+        }
+      }
+    },
+    "maple": {
+      "type": "object",
+      "description": "MAPLE TUI state, managed by the maple binary.",
+      "additionalProperties": false,
+      "properties": {
+        "sessions": {
+          "type": "object",
+          "description": "Pinned harness session IDs, set by the MAPLE TUI (o key auto-pins, p key manual-pins).",
+          "additionalProperties": false,
+          "properties": {
+            "claude": { "type": "string", "default": "" },
+            "opencode": { "type": "string", "default": "" },
+            "copilot": { "type": "string", "default": "" }
+          }
         }
       }
     },

--- a/template/.claude/schemas/project.config.schema.json
+++ b/template/.claude/schemas/project.config.schema.json
@@ -127,12 +127,24 @@
       "properties": {
         "project_number": {
           "type": ["integer", "null"],
-          "description": "GitHub Project v2 number (numeric ID, not node ID). Set by `maple project bootstrap`.",
+          "description": "GitHub Project v2 number. null = ask once; 0 = user declined the board; N = configured board. Set by `maple project bootstrap`.",
+          "minimum": 0,
           "default": null
         },
         "project_node_id": {
           "type": ["string", "null"],
           "description": "GitHub Project v2 GraphQL node ID. Set by `maple project bootstrap`.",
+          "default": null
+        },
+        "status_field_id": {
+          "type": ["string", "null"],
+          "description": "GitHub Project v2 Status single-select field node ID, used to set a card's Status. Cached by gh-projects / `maple project bootstrap`.",
+          "default": null
+        },
+        "milestone_granularity": {
+          "type": ["string", "null"],
+          "description": "Which SemVer classes get their own milestone. null = ask the user once; none = declined (no milestones); minor = major & minor only (vX.Y.0), patches attach to their minor; patch = also give patches their own milestone.",
+          "enum": [null, "none", "minor", "patch"],
           "default": null
         }
       }

--- a/template/.claude/skills/gh-issues/SKILL.md
+++ b/template/.claude/skills/gh-issues/SKILL.md
@@ -44,6 +44,16 @@ ISSUE_URL=$(echo "$RESULT"    | python3 -c "import sys,json; d=json.load(sys.std
 ISSUE_NODE=$(echo "$RESULT"   | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['id'])")
 ```
 
+### Version & Issue Tracking labels + milestone
+
+- **Label** with the `type:*` taxonomy from `gh-labels-milestones` — `type:bug`
+  for a fix/patch, `type:feature` for a feature/minor/major (also `type:docs` /
+  `type:refactor` / `type:chore` as fitting). Never `bug`/`enhancement`.
+- **Milestone** is the target major/minor `vX.Y.0` chosen by the granularity gate
+  in `gh-labels-milestones`, not the static `project.milestone`. When
+  `github.milestone_granularity` is `none`, **omit** the `--milestone` flag
+  entirely (passing an empty milestone errors).
+
 ## View an Issue
 
 ```bash

--- a/template/.claude/skills/gh-labels-milestones/SKILL.md
+++ b/template/.claude/skills/gh-labels-milestones/SKILL.md
@@ -132,6 +132,44 @@ upsert_milestone() {
 upsert_milestone "v1.0" "2025-12-31" "Initial release"
 ```
 
+## Milestone granularity gate (ask once, then persist)
+
+Whether a change gets a milestone is driven by `github.milestone_granularity` in
+`project.config.yaml`. An absent key in an older config counts as `null`.
+
+```bash
+GRANULARITY=$(python3 -c "
+for line in open('project.config.yaml'):
+    s = line.strip()
+    if s.startswith('milestone_granularity:'):
+        v = s.split(':', 1)[1].split('#', 1)[0].strip().strip('\"').strip(\"'\")
+        print(v); break
+")
+```
+
+- **`null` or empty** — not yet decided. Ask the user **once**:
+  "Track milestones for this project? (yes = major & minor releases / no = skip)".
+  Persist the answer so we never re-ask:
+  ```bash
+  python3 - "$ANSWER" <<'PY'   # ANSWER = "minor" (yes) or "none" (no)
+  import re, sys
+  val = sys.argv[1]
+  p = 'project.config.yaml'; s = open(p).read()
+  s = re.sub(r'(milestone_granularity:\s*)null', r'\g<1>' + val, s, count=1)
+  open(p, 'w').write(s)
+  PY
+  ```
+- **`none`** — declined. Skip milestones entirely.
+- **`minor`** (default when enabled) — **major & minor only**. Ensure `vX.Y.0`
+  exists (`upsert_milestone`); a **patch** attaches to its minor's `vX.Y.0` and
+  never gets its own milestone.
+- **`patch`** — also give patches their own `vX.Y.Z` milestone.
+
+The label taxonomy (`type:bug` / `type:feature` / `type:docs` / `type:refactor` /
+`type:chore`) is the single source of truth defined above under **Type Labels** —
+map the SemVer class to it (`type:bug` for a fix/patch, `type:feature` for a
+feature/minor/major). Do not invent `bug`/`enhancement` labels.
+
 ## Assign Labels to an Issue
 
 ```bash

--- a/template/.claude/skills/gh-labels-milestones/SKILL.md
+++ b/template/.claude/skills/gh-labels-milestones/SKILL.md
@@ -149,13 +149,19 @@ for line in open('project.config.yaml'):
 
 - **`null` or empty** — not yet decided. Ask the user **once**:
   "Track milestones for this project? (yes = major & minor releases / no = skip)".
-  Persist the answer so we never re-ask:
+  Persist the answer so we never re-ask. The key is **absent** in older configs,
+  so replace it if present, otherwise insert it under the `github:` block:
   ```bash
   python3 - "$ANSWER" <<'PY'   # ANSWER = "minor" (yes) or "none" (no)
   import re, sys
   val = sys.argv[1]
   p = 'project.config.yaml'; s = open(p).read()
-  s = re.sub(r'(milestone_granularity:\s*)null', r'\g<1>' + val, s, count=1)
+  if re.search(r'^\s*milestone_granularity:', s, re.M):
+      s = re.sub(r'(^\s*milestone_granularity:\s*)\S+', r'\g<1>' + val, s, count=1, flags=re.M)
+  elif re.search(r'^github:\s*$', s, re.M):
+      s = re.sub(r'(^github:\s*\n)', r'\g<1>  milestone_granularity: ' + val + '\n', s, count=1, flags=re.M)
+  else:
+      s = s.rstrip('\n') + '\ngithub:\n  milestone_granularity: ' + val + '\n'
   open(p, 'w').write(s)
   PY
   ```

--- a/template/.claude/skills/gh-projects/SKILL.md
+++ b/template/.claude/skills/gh-projects/SKILL.md
@@ -13,32 +13,61 @@ Manage GitHub Projects v2 board operations: add issues as cards, update field va
 
 | Field | Source | Example |
 |---|---|---|
-| `project_number` | `project.config.yaml` | `3` |
+| `project_number` | `project.config.yaml` (`github.project_number`) | `3` — `null` = ask once; `0` = declined |
 | `project_node_id` | `project.config.yaml` | `"PVT_kwDO..."` |
+| `status_field_id` | `project.config.yaml` (`github.status_field_id`) | `"PVTSSF_..."` |
 | `issue_node_id` | `gh-issues` skill output | `"I_kwDO..."` |
 | `issue_number` | `gh-issues` skill output | `42` |
 | `field_name` | project field name | `"Status"` |
-| `field_value` | target option name | `"In Progress"` |
+| `field_value` | target option name | `"In Progress"` (capital P — GitHub's default option) |
 
 ## Read project config
 
-```bash
-PROJECT_NUMBER=$(python3 -c "
-import sys
-for line in open('project.config.yaml'):
-    if 'project_number:' in line:
-        print(line.split(':')[1].strip())
-        break
-")
+Parse the `github.*` values robustly — strip inline comments (`#…`) and quotes, so
+values like `project_number: null    # null = ask once` read as `null`, not the
+whole comment:
 
-PROJECT_NODE=$(python3 -c "
+```bash
+cfg_get() {  # cfg_get <key> → prints value or empty
+  python3 -c "
 import sys
+key = '$1'
 for line in open('project.config.yaml'):
-    if 'project_node_id:' in line:
-        print(line.split(':', 1)[1].strip())
+    s = line.strip()
+    if s.startswith(key + ':'):
+        v = s.split(':', 1)[1]
+        v = v.split('#', 1)[0].strip().strip('\"').strip(\"'\")
+        print(v)
         break
-")
+"
+}
+
+PROJECT_NUMBER=$(cfg_get project_number)   # "" if absent (old config) → treat as null
+PROJECT_NODE=$(cfg_get project_node_id)
+STATUS_FIELD_ID=$(cfg_get status_field_id)
 ```
+
+## Board configuration gate (ask once, then persist)
+
+Run this before adding any card. `project_number` has three states — an absent key
+in an older config counts as `null`:
+
+- **`null` or empty** — not yet decided. Ask the user **once**:
+  "Add issues to a GitHub project board? (yes → bootstrap a board / no → skip)".
+  - **yes** → run `maple project` (or bootstrap via GraphQL); it writes
+    `project_number`, `project_node_id`, and `status_field_id` back to
+    `project.config.yaml`. Continue.
+  - **no** → persist the decline so we never re-ask, then skip the board:
+    ```bash
+    python3 - <<'PY'
+    import re
+    p = 'project.config.yaml'; s = open(p).read()
+    s = re.sub(r'(project_number:\s*)null', r'\g<1>0', s, count=1)
+    open(p, 'w').write(s)
+    PY
+    ```
+- **`0`** — user declined. Skip all board operations silently.
+- **`> 0`** — configured. Proceed with add + Status updates below.
 
 ## Add an Issue to the Project Board
 
@@ -109,6 +138,10 @@ for f in d['data']['node']['fields']['nodes']:
 ```
 
 ## Update a Single-Select Field (Status, Type, ADR Required)
+
+For the **Status** field, use the cached `$STATUS_FIELD_ID` from config as
+`$FIELD_ID` when it is set — skip the field-ID lookup. Fall back to the fetch
+above only when it is empty.
 
 ```bash
 gh api graphql -f query='

--- a/template/.cursor/agents/orchestrator.md
+++ b/template/.cursor/agents/orchestrator.md
@@ -262,7 +262,15 @@ If failure → return to Phase 5.
 On success: Create PR via gh pr create, post completion summary.
 
 ## GitHub Issue Management
-Every feature has a corresponding GitHub issue. Update issues at each phase transition:
+
+### Version & Issue Tracking (mandatory — every change)
+Gate on a GitHub repo first (`project.repo` or a git remote); if none, skip this. Then classify the SemVer bump — **major** (breaking) / **minor** (new backward-compatible feature) / **patch** (bug fix, no API change) — and:
+- **Milestone — major & minor only.** Read `github.milestone_granularity` (absent = `null`). `null` → ask the user once, persist `minor` (yes) / `none` (no). `minor` → ensure `vX.Y.0` exists (`gh-labels-milestones`); a patch attaches to its minor's `vX.Y.0`, never its own. `patch` → patches get their own. `none` → skip.
+- **Issue — every change.** Labelled the matching **`type:*`** label (`type:bug` fix · `type:feature` feature · `type:docs`/`type:refactor`/`type:chore`, per `gh-labels-milestones`), assigned to the target major/minor milestone (`gh-issues`). Never `bug`/`enhancement`.
+- **Project board.** Read `github.project_number` (absent = `null`). `null` → ask once; if yes bootstrap (`maple project` / `gh-projects`) and write it back to config, if no persist `0`. `0` → skip. `> 0` → add the issue and set **Status** (`In Progress` → `Done`), reading the number from `project.config.yaml`, never hard-coded.
+- PR `Closes #N`. **No Claude/Anthropic attribution** anywhere.
+
+Every change has a corresponding GitHub issue. Update issues at each phase transition:
 
 ```bash
 # Create issue (done by @product-owner, but you track)

--- a/template/.cursor/rules/version-and-issues.mdc
+++ b/template/.cursor/rules/version-and-issues.mdc
@@ -1,0 +1,17 @@
+---
+description: Version & issue tracking — every change gets a SemVer class, an issue with the matching type:* label, a major/minor milestone, and a card on the configured project board (project.config.yaml)
+alwaysApply: true
+---
+
+## Version & Issue Tracking (mandatory)
+
+Every change we work on is tracked — automatic, not optional. When you start a piece of work (and before you finish it):
+
+1. **Gate on a GitHub repo.** If `project.repo` is empty and there is no git remote, skip this rule silently.
+2. **Classify the SemVer bump** — **major** (breaking) / **minor** (new backward-compatible feature) / **patch** (bug fix, no API change), per the scheme in `project.config.yaml`.
+3. **Milestone — major & minor only.** Read `github.milestone_granularity` (an absent key counts as `null`). `null` → ask the user once and persist the answer (`minor` = yes / `none` = no). `minor` → ensure `vX.Y.0` exists; a patch attaches to its minor's `vX.Y.0`, never its own. `patch` → patches get their own too. `none` → skip milestones.
+4. **Issue — every change.** Create a GitHub issue labelled the matching **`type:*`** label (`type:bug` fix · `type:feature` feature · `type:docs`/`type:refactor`/`type:chore`, per `gh-labels-milestones`), assigned to the target major/minor milestone when milestones are enabled. Never `bug`/`enhancement`.
+5. **Project board.** Read `github.project_number` (absent = `null`). `null` → ask the user once; if yes, bootstrap (`maple project` / `gh-projects`) and write the number back to config; if no, persist `0`. `0` → skip the board. `> 0` → add the issue and set **Status** (`In Progress` while working, `Done` when shipped) — read the number from `project.config.yaml`, never hard-code it.
+6. **Link & close.** The PR references the issue (`Closes #N`); merging closes it. On release the milestone version equals the release tag. **No Claude/Anthropic attribution** anywhere — commits, PR bodies, issues, releases.
+
+Mechanics live in the maple skills — use them, don't hand-roll: `gh-labels-milestones` (milestone/label upsert + granularity gate), `gh-issues` (create/label/milestone), `gh-projects` (board add + Status). Config: `project.config.yaml → github`.

--- a/template/.cursor/rules/version-and-issues.mdc
+++ b/template/.cursor/rules/version-and-issues.mdc
@@ -7,7 +7,7 @@ alwaysApply: true
 
 Every change we work on is tracked — automatic, not optional. When you start a piece of work (and before you finish it):
 
-1. **Gate on a GitHub repo.** If `project.repo` is empty and there is no git remote, skip this rule silently.
+1. **Gate on a GitHub repo.** If `project.repo` is empty and there is no git remote, skip this section silently.
 2. **Classify the SemVer bump** — **major** (breaking) / **minor** (new backward-compatible feature) / **patch** (bug fix, no API change), per the scheme in `project.config.yaml`.
 3. **Milestone — major & minor only.** Read `github.milestone_granularity` (an absent key counts as `null`). `null` → ask the user once and persist the answer (`minor` = yes / `none` = no). `minor` → ensure `vX.Y.0` exists; a patch attaches to its minor's `vX.Y.0`, never its own. `patch` → patches get their own too. `none` → skip milestones.
 4. **Issue — every change.** Create a GitHub issue labelled the matching **`type:*`** label (`type:bug` fix · `type:feature` feature · `type:docs`/`type:refactor`/`type:chore`, per `gh-labels-milestones`), assigned to the target major/minor milestone when milestones are enabled. Never `bug`/`enhancement`.

--- a/template/.cursor/skills/gh-issues/SKILL.md
+++ b/template/.cursor/skills/gh-issues/SKILL.md
@@ -44,6 +44,16 @@ ISSUE_URL=$(echo "$RESULT"    | python3 -c "import sys,json; d=json.load(sys.std
 ISSUE_NODE=$(echo "$RESULT"   | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['id'])")
 ```
 
+### Version & Issue Tracking labels + milestone
+
+- **Label** with the `type:*` taxonomy from `gh-labels-milestones` — `type:bug`
+  for a fix/patch, `type:feature` for a feature/minor/major (also `type:docs` /
+  `type:refactor` / `type:chore` as fitting). Never `bug`/`enhancement`.
+- **Milestone** is the target major/minor `vX.Y.0` chosen by the granularity gate
+  in `gh-labels-milestones`, not the static `project.milestone`. When
+  `github.milestone_granularity` is `none`, **omit** the `--milestone` flag
+  entirely (passing an empty milestone errors).
+
 ## View an Issue
 
 ```bash

--- a/template/.cursor/skills/gh-labels-milestones/SKILL.md
+++ b/template/.cursor/skills/gh-labels-milestones/SKILL.md
@@ -132,6 +132,44 @@ upsert_milestone() {
 upsert_milestone "v1.0" "2025-12-31" "Initial release"
 ```
 
+## Milestone granularity gate (ask once, then persist)
+
+Whether a change gets a milestone is driven by `github.milestone_granularity` in
+`project.config.yaml`. An absent key in an older config counts as `null`.
+
+```bash
+GRANULARITY=$(python3 -c "
+for line in open('project.config.yaml'):
+    s = line.strip()
+    if s.startswith('milestone_granularity:'):
+        v = s.split(':', 1)[1].split('#', 1)[0].strip().strip('\"').strip(\"'\")
+        print(v); break
+")
+```
+
+- **`null` or empty** — not yet decided. Ask the user **once**:
+  "Track milestones for this project? (yes = major & minor releases / no = skip)".
+  Persist the answer so we never re-ask:
+  ```bash
+  python3 - "$ANSWER" <<'PY'   # ANSWER = "minor" (yes) or "none" (no)
+  import re, sys
+  val = sys.argv[1]
+  p = 'project.config.yaml'; s = open(p).read()
+  s = re.sub(r'(milestone_granularity:\s*)null', r'\g<1>' + val, s, count=1)
+  open(p, 'w').write(s)
+  PY
+  ```
+- **`none`** — declined. Skip milestones entirely.
+- **`minor`** (default when enabled) — **major & minor only**. Ensure `vX.Y.0`
+  exists (`upsert_milestone`); a **patch** attaches to its minor's `vX.Y.0` and
+  never gets its own milestone.
+- **`patch`** — also give patches their own `vX.Y.Z` milestone.
+
+The label taxonomy (`type:bug` / `type:feature` / `type:docs` / `type:refactor` /
+`type:chore`) is the single source of truth defined above under **Type Labels** —
+map the SemVer class to it (`type:bug` for a fix/patch, `type:feature` for a
+feature/minor/major). Do not invent `bug`/`enhancement` labels.
+
 ## Assign Labels to an Issue
 
 ```bash

--- a/template/.cursor/skills/gh-labels-milestones/SKILL.md
+++ b/template/.cursor/skills/gh-labels-milestones/SKILL.md
@@ -149,13 +149,19 @@ for line in open('project.config.yaml'):
 
 - **`null` or empty** — not yet decided. Ask the user **once**:
   "Track milestones for this project? (yes = major & minor releases / no = skip)".
-  Persist the answer so we never re-ask:
+  Persist the answer so we never re-ask. The key is **absent** in older configs,
+  so replace it if present, otherwise insert it under the `github:` block:
   ```bash
   python3 - "$ANSWER" <<'PY'   # ANSWER = "minor" (yes) or "none" (no)
   import re, sys
   val = sys.argv[1]
   p = 'project.config.yaml'; s = open(p).read()
-  s = re.sub(r'(milestone_granularity:\s*)null', r'\g<1>' + val, s, count=1)
+  if re.search(r'^\s*milestone_granularity:', s, re.M):
+      s = re.sub(r'(^\s*milestone_granularity:\s*)\S+', r'\g<1>' + val, s, count=1, flags=re.M)
+  elif re.search(r'^github:\s*$', s, re.M):
+      s = re.sub(r'(^github:\s*\n)', r'\g<1>  milestone_granularity: ' + val + '\n', s, count=1, flags=re.M)
+  else:
+      s = s.rstrip('\n') + '\ngithub:\n  milestone_granularity: ' + val + '\n'
   open(p, 'w').write(s)
   PY
   ```

--- a/template/.cursor/skills/gh-projects/SKILL.md
+++ b/template/.cursor/skills/gh-projects/SKILL.md
@@ -13,32 +13,61 @@ Manage GitHub Projects v2 board operations: add issues as cards, update field va
 
 | Field | Source | Example |
 |---|---|---|
-| `project_number` | `project.config.yaml` | `3` |
+| `project_number` | `project.config.yaml` (`github.project_number`) | `3` — `null` = ask once; `0` = declined |
 | `project_node_id` | `project.config.yaml` | `"PVT_kwDO..."` |
+| `status_field_id` | `project.config.yaml` (`github.status_field_id`) | `"PVTSSF_..."` |
 | `issue_node_id` | `gh-issues` skill output | `"I_kwDO..."` |
 | `issue_number` | `gh-issues` skill output | `42` |
 | `field_name` | project field name | `"Status"` |
-| `field_value` | target option name | `"In Progress"` |
+| `field_value` | target option name | `"In Progress"` (capital P — GitHub's default option) |
 
 ## Read project config
 
-```bash
-PROJECT_NUMBER=$(python3 -c "
-import sys
-for line in open('project.config.yaml'):
-    if 'project_number:' in line:
-        print(line.split(':')[1].strip())
-        break
-")
+Parse the `github.*` values robustly — strip inline comments (`#…`) and quotes, so
+values like `project_number: null    # null = ask once` read as `null`, not the
+whole comment:
 
-PROJECT_NODE=$(python3 -c "
+```bash
+cfg_get() {  # cfg_get <key> → prints value or empty
+  python3 -c "
 import sys
+key = '$1'
 for line in open('project.config.yaml'):
-    if 'project_node_id:' in line:
-        print(line.split(':', 1)[1].strip())
+    s = line.strip()
+    if s.startswith(key + ':'):
+        v = s.split(':', 1)[1]
+        v = v.split('#', 1)[0].strip().strip('\"').strip(\"'\")
+        print(v)
         break
-")
+"
+}
+
+PROJECT_NUMBER=$(cfg_get project_number)   # "" if absent (old config) → treat as null
+PROJECT_NODE=$(cfg_get project_node_id)
+STATUS_FIELD_ID=$(cfg_get status_field_id)
 ```
+
+## Board configuration gate (ask once, then persist)
+
+Run this before adding any card. `project_number` has three states — an absent key
+in an older config counts as `null`:
+
+- **`null` or empty** — not yet decided. Ask the user **once**:
+  "Add issues to a GitHub project board? (yes → bootstrap a board / no → skip)".
+  - **yes** → run `maple project` (or bootstrap via GraphQL); it writes
+    `project_number`, `project_node_id`, and `status_field_id` back to
+    `project.config.yaml`. Continue.
+  - **no** → persist the decline so we never re-ask, then skip the board:
+    ```bash
+    python3 - <<'PY'
+    import re
+    p = 'project.config.yaml'; s = open(p).read()
+    s = re.sub(r'(project_number:\s*)null', r'\g<1>0', s, count=1)
+    open(p, 'w').write(s)
+    PY
+    ```
+- **`0`** — user declined. Skip all board operations silently.
+- **`> 0`** — configured. Proceed with add + Status updates below.
 
 ## Add an Issue to the Project Board
 
@@ -109,6 +138,10 @@ for f in d['data']['node']['fields']['nodes']:
 ```
 
 ## Update a Single-Select Field (Status, Type, ADR Required)
+
+For the **Status** field, use the cached `$STATUS_FIELD_ID` from config as
+`$FIELD_ID` when it is set — skip the field-ID lookup. Fall back to the fetch
+above only when it is empty.
 
 ```bash
 gh api graphql -f query='

--- a/template/.github/copilot-instructions.md
+++ b/template/.github/copilot-instructions.md
@@ -202,3 +202,16 @@ Insert design sub-pipeline before IMPLEMENT:
 | Design system | `docs/design/system/components/` |
 
 Never write design artifacts to `docs/wireframes/`, `docs/identity/`, `docs/mockups/`, or any location outside `docs/design/`.
+
+## Version & Issue Tracking (mandatory)
+
+Every change we work on is tracked — automatic, not optional. When you start a piece of work (and before you finish it):
+
+1. **Gate on a GitHub repo.** If `project.repo` is empty and there is no git remote, skip this section silently.
+2. **Classify the SemVer bump** — **major** (breaking) / **minor** (new backward-compatible feature) / **patch** (bug fix, no API change), per the scheme in `project.config.yaml`.
+3. **Milestone — major & minor only.** Read `github.milestone_granularity` (an absent key counts as `null`). `null` → ask the user once and persist the answer (`minor` = yes / `none` = no). `minor` → ensure `vX.Y.0` exists; a patch attaches to its minor's `vX.Y.0`, never its own. `patch` → patches get their own too. `none` → skip milestones.
+4. **Issue — every change.** Create a GitHub issue labelled the matching **`type:*`** label (`type:bug` fix · `type:feature` feature · `type:docs`/`type:refactor`/`type:chore`, per `gh-labels-milestones`), assigned to the target major/minor milestone when milestones are enabled. Never `bug`/`enhancement`.
+5. **Project board.** Read `github.project_number` (absent = `null`). `null` → ask the user once; if yes, bootstrap (`maple project` / `gh-projects`) and write the number back to config; if no, persist `0`. `0` → skip the board. `> 0` → add the issue and set **Status** (`In Progress` while working, `Done` when shipped) — read the number from `project.config.yaml`, never hard-code it.
+6. **Link & close.** The PR references the issue (`Closes #N`); merging closes it. On release the milestone version equals the release tag. **No Claude/Anthropic attribution** anywhere — commits, PR bodies, issues, releases.
+
+Mechanics live in the maple skills — use them, don't hand-roll: `gh-labels-milestones` (milestone/label upsert + granularity gate), `gh-issues` (create/label/milestone), `gh-projects` (board add + Status). Config: `project.config.yaml → github`.

--- a/template/.opencode/agents/orchestrator.md
+++ b/template/.opencode/agents/orchestrator.md
@@ -266,7 +266,15 @@ If failure → return to Phase 5.
 On success: Create PR via gh pr create, post completion summary.
 
 ## GitHub Issue Management
-Every feature has a corresponding GitHub issue. Update issues at each phase transition:
+
+### Version & Issue Tracking (mandatory — every change)
+Gate on a GitHub repo first (`project.repo` or a git remote); if none, skip this. Then classify the SemVer bump — **major** (breaking) / **minor** (new backward-compatible feature) / **patch** (bug fix, no API change) — and:
+- **Milestone — major & minor only.** Read `github.milestone_granularity` (absent = `null`). `null` → ask the user once, persist `minor` (yes) / `none` (no). `minor` → ensure `vX.Y.0` exists (`gh-labels-milestones`); a patch attaches to its minor's `vX.Y.0`, never its own. `patch` → patches get their own. `none` → skip.
+- **Issue — every change.** Labelled the matching **`type:*`** label (`type:bug` fix · `type:feature` feature · `type:docs`/`type:refactor`/`type:chore`, per `gh-labels-milestones`), assigned to the target major/minor milestone (`gh-issues`). Never `bug`/`enhancement`.
+- **Project board.** Read `github.project_number` (absent = `null`). `null` → ask once; if yes bootstrap (`maple project` / `gh-projects`) and write it back to config, if no persist `0`. `0` → skip. `> 0` → add the issue and set **Status** (`In Progress` → `Done`), reading the number from `project.config.yaml`, never hard-coded.
+- PR `Closes #N`. **No Claude/Anthropic attribution** anywhere.
+
+Every change has a corresponding GitHub issue. Update issues at each phase transition:
 
 ```bash
 # Create issue (done by @product-owner, but you track)

--- a/template/.opencode/skills/gh-issues/SKILL.md
+++ b/template/.opencode/skills/gh-issues/SKILL.md
@@ -44,6 +44,16 @@ ISSUE_URL=$(echo "$RESULT"    | python3 -c "import sys,json; d=json.load(sys.std
 ISSUE_NODE=$(echo "$RESULT"   | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['id'])")
 ```
 
+### Version & Issue Tracking labels + milestone
+
+- **Label** with the `type:*` taxonomy from `gh-labels-milestones` — `type:bug`
+  for a fix/patch, `type:feature` for a feature/minor/major (also `type:docs` /
+  `type:refactor` / `type:chore` as fitting). Never `bug`/`enhancement`.
+- **Milestone** is the target major/minor `vX.Y.0` chosen by the granularity gate
+  in `gh-labels-milestones`, not the static `project.milestone`. When
+  `github.milestone_granularity` is `none`, **omit** the `--milestone` flag
+  entirely (passing an empty milestone errors).
+
 ## View an Issue
 
 ```bash

--- a/template/.opencode/skills/gh-labels-milestones/SKILL.md
+++ b/template/.opencode/skills/gh-labels-milestones/SKILL.md
@@ -132,6 +132,44 @@ upsert_milestone() {
 upsert_milestone "v1.0" "2025-12-31" "Initial release"
 ```
 
+## Milestone granularity gate (ask once, then persist)
+
+Whether a change gets a milestone is driven by `github.milestone_granularity` in
+`project.config.yaml`. An absent key in an older config counts as `null`.
+
+```bash
+GRANULARITY=$(python3 -c "
+for line in open('project.config.yaml'):
+    s = line.strip()
+    if s.startswith('milestone_granularity:'):
+        v = s.split(':', 1)[1].split('#', 1)[0].strip().strip('\"').strip(\"'\")
+        print(v); break
+")
+```
+
+- **`null` or empty** — not yet decided. Ask the user **once**:
+  "Track milestones for this project? (yes = major & minor releases / no = skip)".
+  Persist the answer so we never re-ask:
+  ```bash
+  python3 - "$ANSWER" <<'PY'   # ANSWER = "minor" (yes) or "none" (no)
+  import re, sys
+  val = sys.argv[1]
+  p = 'project.config.yaml'; s = open(p).read()
+  s = re.sub(r'(milestone_granularity:\s*)null', r'\g<1>' + val, s, count=1)
+  open(p, 'w').write(s)
+  PY
+  ```
+- **`none`** — declined. Skip milestones entirely.
+- **`minor`** (default when enabled) — **major & minor only**. Ensure `vX.Y.0`
+  exists (`upsert_milestone`); a **patch** attaches to its minor's `vX.Y.0` and
+  never gets its own milestone.
+- **`patch`** — also give patches their own `vX.Y.Z` milestone.
+
+The label taxonomy (`type:bug` / `type:feature` / `type:docs` / `type:refactor` /
+`type:chore`) is the single source of truth defined above under **Type Labels** —
+map the SemVer class to it (`type:bug` for a fix/patch, `type:feature` for a
+feature/minor/major). Do not invent `bug`/`enhancement` labels.
+
 ## Assign Labels to an Issue
 
 ```bash

--- a/template/.opencode/skills/gh-labels-milestones/SKILL.md
+++ b/template/.opencode/skills/gh-labels-milestones/SKILL.md
@@ -149,13 +149,19 @@ for line in open('project.config.yaml'):
 
 - **`null` or empty** — not yet decided. Ask the user **once**:
   "Track milestones for this project? (yes = major & minor releases / no = skip)".
-  Persist the answer so we never re-ask:
+  Persist the answer so we never re-ask. The key is **absent** in older configs,
+  so replace it if present, otherwise insert it under the `github:` block:
   ```bash
   python3 - "$ANSWER" <<'PY'   # ANSWER = "minor" (yes) or "none" (no)
   import re, sys
   val = sys.argv[1]
   p = 'project.config.yaml'; s = open(p).read()
-  s = re.sub(r'(milestone_granularity:\s*)null', r'\g<1>' + val, s, count=1)
+  if re.search(r'^\s*milestone_granularity:', s, re.M):
+      s = re.sub(r'(^\s*milestone_granularity:\s*)\S+', r'\g<1>' + val, s, count=1, flags=re.M)
+  elif re.search(r'^github:\s*$', s, re.M):
+      s = re.sub(r'(^github:\s*\n)', r'\g<1>  milestone_granularity: ' + val + '\n', s, count=1, flags=re.M)
+  else:
+      s = s.rstrip('\n') + '\ngithub:\n  milestone_granularity: ' + val + '\n'
   open(p, 'w').write(s)
   PY
   ```

--- a/template/.opencode/skills/gh-projects/SKILL.md
+++ b/template/.opencode/skills/gh-projects/SKILL.md
@@ -13,32 +13,61 @@ Manage GitHub Projects v2 board operations: add issues as cards, update field va
 
 | Field | Source | Example |
 |---|---|---|
-| `project_number` | `project.config.yaml` | `3` |
+| `project_number` | `project.config.yaml` (`github.project_number`) | `3` — `null` = ask once; `0` = declined |
 | `project_node_id` | `project.config.yaml` | `"PVT_kwDO..."` |
+| `status_field_id` | `project.config.yaml` (`github.status_field_id`) | `"PVTSSF_..."` |
 | `issue_node_id` | `gh-issues` skill output | `"I_kwDO..."` |
 | `issue_number` | `gh-issues` skill output | `42` |
 | `field_name` | project field name | `"Status"` |
-| `field_value` | target option name | `"In Progress"` |
+| `field_value` | target option name | `"In Progress"` (capital P — GitHub's default option) |
 
 ## Read project config
 
-```bash
-PROJECT_NUMBER=$(python3 -c "
-import sys
-for line in open('project.config.yaml'):
-    if 'project_number:' in line:
-        print(line.split(':')[1].strip())
-        break
-")
+Parse the `github.*` values robustly — strip inline comments (`#…`) and quotes, so
+values like `project_number: null    # null = ask once` read as `null`, not the
+whole comment:
 
-PROJECT_NODE=$(python3 -c "
+```bash
+cfg_get() {  # cfg_get <key> → prints value or empty
+  python3 -c "
 import sys
+key = '$1'
 for line in open('project.config.yaml'):
-    if 'project_node_id:' in line:
-        print(line.split(':', 1)[1].strip())
+    s = line.strip()
+    if s.startswith(key + ':'):
+        v = s.split(':', 1)[1]
+        v = v.split('#', 1)[0].strip().strip('\"').strip(\"'\")
+        print(v)
         break
-")
+"
+}
+
+PROJECT_NUMBER=$(cfg_get project_number)   # "" if absent (old config) → treat as null
+PROJECT_NODE=$(cfg_get project_node_id)
+STATUS_FIELD_ID=$(cfg_get status_field_id)
 ```
+
+## Board configuration gate (ask once, then persist)
+
+Run this before adding any card. `project_number` has three states — an absent key
+in an older config counts as `null`:
+
+- **`null` or empty** — not yet decided. Ask the user **once**:
+  "Add issues to a GitHub project board? (yes → bootstrap a board / no → skip)".
+  - **yes** → run `maple project` (or bootstrap via GraphQL); it writes
+    `project_number`, `project_node_id`, and `status_field_id` back to
+    `project.config.yaml`. Continue.
+  - **no** → persist the decline so we never re-ask, then skip the board:
+    ```bash
+    python3 - <<'PY'
+    import re
+    p = 'project.config.yaml'; s = open(p).read()
+    s = re.sub(r'(project_number:\s*)null', r'\g<1>0', s, count=1)
+    open(p, 'w').write(s)
+    PY
+    ```
+- **`0`** — user declined. Skip all board operations silently.
+- **`> 0`** — configured. Proceed with add + Status updates below.
 
 ## Add an Issue to the Project Board
 
@@ -109,6 +138,10 @@ for f in d['data']['node']['fields']['nodes']:
 ```
 
 ## Update a Single-Select Field (Status, Type, ADR Required)
+
+For the **Status** field, use the cached `$STATUS_FIELD_ID` from config as
+`$FIELD_ID` when it is set — skip the field-ID lookup. Fall back to the fetch
+above only when it is empty.
 
 ```bash
 gh api graphql -f query='

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -63,3 +63,18 @@ All agents use: `make build`, `make test`, `make test-integration`, `make test-e
 - Conventional Commits: `feat:`, `fix:`, `test:`, `docs:`, `infra:`, `refactor:`
 - Branch naming: `feat/{slug}`, `fix/{slug}`
 - Squash merge to main
+
+---
+
+## Version & Issue Tracking (mandatory)
+
+Every change we work on is tracked — automatic, not optional. When you start a piece of work (and before you finish it):
+
+1. **Gate on a GitHub repo.** If `project.repo` is empty and there is no git remote, skip this section silently.
+2. **Classify the SemVer bump** — **major** (breaking) / **minor** (new backward-compatible feature) / **patch** (bug fix, no API change), per the scheme in `project.config.yaml`.
+3. **Milestone — major & minor only.** Read `github.milestone_granularity` (an absent key counts as `null`). `null` → ask the user once and persist the answer (`minor` = yes / `none` = no). `minor` → ensure `vX.Y.0` exists; a patch attaches to its minor's `vX.Y.0`, never its own. `patch` → patches get their own too. `none` → skip milestones.
+4. **Issue — every change.** Create a GitHub issue labelled the matching **`type:*`** label (`type:bug` fix · `type:feature` feature · `type:docs`/`type:refactor`/`type:chore`, per `gh-labels-milestones`), assigned to the target major/minor milestone when milestones are enabled. Never `bug`/`enhancement`.
+5. **Project board.** Read `github.project_number` (absent = `null`). `null` → ask the user once; if yes, bootstrap (`maple project` / `gh-projects`) and write the number back to config; if no, persist `0`. `0` → skip the board. `> 0` → add the issue and set **Status** (`In Progress` while working, `Done` when shipped) — read the number from `project.config.yaml`, never hard-code it.
+6. **Link & close.** The PR references the issue (`Closes #N`); merging closes it. On release the milestone version equals the release tag. **No Claude/Anthropic attribution** anywhere — commits, PR bodies, issues, releases.
+
+Mechanics live in the maple skills — use them, don't hand-roll: `gh-labels-milestones` (milestone/label upsert + granularity gate), `gh-issues` (create/label/milestone), `gh-projects` (board add + Status). Config: `project.config.yaml → github`.

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -50,7 +50,7 @@ Pipeline rules:
 4. QA writes failing tests. Implementation agents make them pass.
 5. 3 consecutive failures on any task → escalate to human.
 6. `make test-all` must pass before Phase 8 gate.
-7. Every feature gets a GitHub issue. Agents update it via `gh` CLI.
+7. Every change gets a GitHub issue, milestone, and project card — see **Version & Issue Tracking** below.
 8. Conventional Commits: `feat:`, `fix:`, `test:`, `docs:`, `infra:`, `refactor:`.
 
 **Gate enforcement:**
@@ -65,6 +65,21 @@ Pipeline rules:
 - Design system components → `docs/design/system/components/`
 - Research → `docs/design/research/`
 - **Never write design artifacts to `docs/wireframes/`, `docs/identity/`, `docs/mockups/`, or any path outside `docs/design/`.**
+
+---
+
+## Version & Issue Tracking (mandatory)
+
+Every change we work on is tracked — automatic, not optional. When you start a piece of work (and before you finish it):
+
+1. **Gate on a GitHub repo.** If `project.repo` is empty and there is no git remote, skip this section silently.
+2. **Classify the SemVer bump** — **major** (breaking) / **minor** (new backward-compatible feature) / **patch** (bug fix, no API change), per the scheme in `project.config.yaml`.
+3. **Milestone — major & minor only.** Read `github.milestone_granularity` (an absent key counts as `null`). `null` → ask the user once and persist the answer (`minor` = yes / `none` = no). `minor` → ensure `vX.Y.0` exists; a patch attaches to its minor's `vX.Y.0`, never its own. `patch` → patches get their own too. `none` → skip milestones.
+4. **Issue — every change.** Create a GitHub issue labelled the matching **`type:*`** label (`type:bug` fix · `type:feature` feature · `type:docs`/`type:refactor`/`type:chore`, per `gh-labels-milestones`), assigned to the target major/minor milestone when milestones are enabled. Never `bug`/`enhancement`.
+5. **Project board.** Read `github.project_number` (absent = `null`). `null` → ask the user once; if yes, bootstrap (`maple project` / `gh-projects`) and write the number back to config; if no, persist `0`. `0` → skip the board. `> 0` → add the issue and set **Status** (`In Progress` while working, `Done` when shipped) — read the number from `project.config.yaml`, never hard-code it.
+6. **Link & close.** The PR references the issue (`Closes #N`); merging closes it. On release the milestone version equals the release tag. **No Claude/Anthropic attribution** anywhere — commits, PR bodies, issues, releases.
+
+Mechanics live in the maple skills — use them, don't hand-roll: `gh-labels-milestones` (milestone/label upsert + granularity gate), `gh-issues` (create/label/milestone), `gh-projects` (board add + Status). Config: `project.config.yaml → github`.
 
 ---
 

--- a/template/COPILOT.md
+++ b/template/COPILOT.md
@@ -73,6 +73,21 @@ Do not emit heartbeat-only timestamp churn.
 - Runtime/test code must not import from `docs/`, `.github/`, or `.claude/`.
 - Copying/adapting reviewed artifacts from docs into app/test code is allowed; path-based imports/references are not.
 
+## Version & Issue Tracking (mandatory)
+
+Every change we work on is tracked — automatic, not optional. When you start a piece of work (and before you finish it):
+
+1. **Gate on a GitHub repo.** If `project.repo` is empty and there is no git remote, skip this section silently.
+2. **Classify the SemVer bump** — **major** (breaking) / **minor** (new backward-compatible feature) / **patch** (bug fix, no API change), per the scheme in `project.config.yaml`.
+3. **Milestone — major & minor only.** Read `github.milestone_granularity` (an absent key counts as `null`). `null` → ask the user once and persist the answer (`minor` = yes / `none` = no). `minor` → ensure `vX.Y.0` exists; a patch attaches to its minor's `vX.Y.0`, never its own. `patch` → patches get their own too. `none` → skip milestones.
+4. **Issue — every change.** Create a GitHub issue labelled the matching **`type:*`** label (`type:bug` fix · `type:feature` feature · `type:docs`/`type:refactor`/`type:chore`, per `gh-labels-milestones`), assigned to the target major/minor milestone when milestones are enabled. Never `bug`/`enhancement`.
+5. **Project board.** Read `github.project_number` (absent = `null`). `null` → ask the user once; if yes, bootstrap (`maple project` / `gh-projects`) and write the number back to config; if no, persist `0`. `0` → skip the board. `> 0` → add the issue and set **Status** (`In Progress` while working, `Done` when shipped) — read the number from `project.config.yaml`, never hard-code it.
+6. **Link & close.** The PR references the issue (`Closes #N`); merging closes it. On release the milestone version equals the release tag. **No Claude/Anthropic attribution** anywhere — commits, PR bodies, issues, releases.
+
+Mechanics live in the maple skills — use them, don't hand-roll: `gh-labels-milestones` (milestone/label upsert + granularity gate), `gh-issues` (create/label/milestone), `gh-projects` (board add + Status). Config: `project.config.yaml → github`.
+
+---
+
 ## Approval Loop
 
 At human-approval gates:

--- a/template/CURSOR.md
+++ b/template/CURSOR.md
@@ -81,6 +81,21 @@ After Phase 7 DOCUMENT, call `/humanizer` to remove AI-isms from prose before me
 
 ---
 
+## Version & Issue Tracking (mandatory)
+
+Every change we work on is tracked — automatic, not optional. When you start a piece of work (and before you finish it):
+
+1. **Gate on a GitHub repo.** If `project.repo` is empty and there is no git remote, skip this section silently.
+2. **Classify the SemVer bump** — **major** (breaking) / **minor** (new backward-compatible feature) / **patch** (bug fix, no API change), per the scheme in `project.config.yaml`.
+3. **Milestone — major & minor only.** Read `github.milestone_granularity` (an absent key counts as `null`). `null` → ask the user once and persist the answer (`minor` = yes / `none` = no). `minor` → ensure `vX.Y.0` exists; a patch attaches to its minor's `vX.Y.0`, never its own. `patch` → patches get their own too. `none` → skip milestones.
+4. **Issue — every change.** Create a GitHub issue labelled the matching **`type:*`** label (`type:bug` fix · `type:feature` feature · `type:docs`/`type:refactor`/`type:chore`, per `gh-labels-milestones`), assigned to the target major/minor milestone when milestones are enabled. Never `bug`/`enhancement`.
+5. **Project board.** Read `github.project_number` (absent = `null`). `null` → ask the user once; if yes, bootstrap (`maple project` / `gh-projects`) and write the number back to config; if no, persist `0`. `0` → skip the board. `> 0` → add the issue and set **Status** (`In Progress` while working, `Done` when shipped) — read the number from `project.config.yaml`, never hard-code it.
+6. **Link & close.** The PR references the issue (`Closes #N`); merging closes it. On release the milestone version equals the release tag. **No Claude/Anthropic attribution** anywhere — commits, PR bodies, issues, releases.
+
+Mechanics live in the maple skills — use them, don't hand-roll: `gh-labels-milestones` (milestone/label upsert + granularity gate), `gh-issues` (create/label/milestone), `gh-projects` (board add + Status). Config: `project.config.yaml → github`.
+
+---
+
 ## Story + Spec Context
 
 Story files live at `docs/stories/<epic>-<story>-<timestamp>-NNNN.md`.

--- a/template/OPENCODE.md
+++ b/template/OPENCODE.md
@@ -75,6 +75,21 @@ After Phase 7 DOCUMENT, call `/humanizer` to remove AI-isms from prose before me
 
 ---
 
+## Version & Issue Tracking (mandatory)
+
+Every change we work on is tracked — automatic, not optional. When you start a piece of work (and before you finish it):
+
+1. **Gate on a GitHub repo.** If `project.repo` is empty and there is no git remote, skip this section silently.
+2. **Classify the SemVer bump** — **major** (breaking) / **minor** (new backward-compatible feature) / **patch** (bug fix, no API change), per the scheme in `project.config.yaml`.
+3. **Milestone — major & minor only.** Read `github.milestone_granularity` (an absent key counts as `null`). `null` → ask the user once and persist the answer (`minor` = yes / `none` = no). `minor` → ensure `vX.Y.0` exists; a patch attaches to its minor's `vX.Y.0`, never its own. `patch` → patches get their own too. `none` → skip milestones.
+4. **Issue — every change.** Create a GitHub issue labelled the matching **`type:*`** label (`type:bug` fix · `type:feature` feature · `type:docs`/`type:refactor`/`type:chore`, per `gh-labels-milestones`), assigned to the target major/minor milestone when milestones are enabled. Never `bug`/`enhancement`.
+5. **Project board.** Read `github.project_number` (absent = `null`). `null` → ask the user once; if yes, bootstrap (`maple project` / `gh-projects`) and write the number back to config; if no, persist `0`. `0` → skip the board. `> 0` → add the issue and set **Status** (`In Progress` while working, `Done` when shipped) — read the number from `project.config.yaml`, never hard-code it.
+6. **Link & close.** The PR references the issue (`Closes #N`); merging closes it. On release the milestone version equals the release tag. **No Claude/Anthropic attribution** anywhere — commits, PR bodies, issues, releases.
+
+Mechanics live in the maple skills — use them, don't hand-roll: `gh-labels-milestones` (milestone/label upsert + granularity gate), `gh-issues` (create/label/milestone), `gh-projects` (board add + Status). Config: `project.config.yaml → github`.
+
+---
+
 ## Story + Spec Context
 
 Story files live at `docs/stories/<epic>-<story>-<timestamp>-NNNN.md`.

--- a/template/project.config.yaml
+++ b/template/project.config.yaml
@@ -51,8 +51,12 @@ design:
   wireframe_format: ascii # ascii | svg | html  (web only)
 
 github:
-  project_number: null    # Set by: maple project bootstrap
+  project_number: null    # null = ask once; 0 = declined; N = configured board (maple project bootstrap)
   project_node_id: null   # Set by: maple project bootstrap
+  status_field_id: null   # Status single-select field id; cached by gh-projects / maple project bootstrap
+  milestone_granularity: null  # null = ask once; none = declined; minor = major+minor (default when enabled); patch = also per-patch
+  # Issue label taxonomy (type:bug | type:feature | type:docs | type:refactor | type:chore)
+  # lives in the gh-labels-milestones skill, not here. See "Version & Issue Tracking" in CLAUDE.md.
 
 maple:
   sessions:

--- a/tui/gh_cmds.go
+++ b/tui/gh_cmds.go
@@ -167,6 +167,15 @@ func runProject(gh string) error {
 	content := string(data)
 	content = strings.ReplaceAll(content, "project_number: null", "project_number: "+number)
 	content = strings.ReplaceAll(content, "project_node_id: null", "project_node_id: \""+nodeID+"\"")
+	// Cache the built-in Status single-select field id so gh-projects can set
+	// Status without re-discovering it. Best-effort — the skill falls back to a
+	// live lookup when this stays null.
+	if sfid := statusFieldID(gh, owner, number); sfid != "" {
+		content = strings.ReplaceAll(content, "status_field_id: null", "status_field_id: \""+sfid+"\"")
+		fmt.Printf("  ✓ Status field id cached: %s\n", sfid)
+	} else {
+		fmt.Printf("  ~ Status field id not found — gh-projects will look it up on first use\n")
+	}
 	if err := os.WriteFile(cfg, []byte(content), 0644); err != nil {
 		return err
 	}
@@ -177,6 +186,20 @@ func runProject(gh string) error {
 		fmt.Printf("  ~ custom fields: %v (project was still created)\n", err)
 	}
 	return nil
+}
+
+// statusFieldID returns the node id of a Project v2's built-in Status
+// single-select field, or "" if it can't be resolved.
+func statusFieldID(gh, owner, number string) string {
+	out, err := runWithTimeout(timeoutNetwork, nil, gh, "project", "field-list", number,
+		"--owner", owner,
+		"--format", "json",
+		"--jq", `.fields[] | select(.name == "Status") | .id`,
+	)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // bootstrapProjectFields adds the standard MAPLE custom fields to a Project v2.

--- a/tui/init.go
+++ b/tui/init.go
@@ -248,8 +248,10 @@ func doInit(tools Tools, fsys fs.FS, force bool) ([]string, error) {
 		{"Makefile", "Makefile"}, // skipped on first copy if already exists when force=false
 		{"lefthook.yml", "lefthook.yml"},
 		{".github", ".github"},
+		{"COPILOT.md", "COPILOT.md"},
 		{".gitignore", ".gitignore"},
 		{".cursor", ".cursor"},
+		{"CURSOR.md", "CURSOR.md"},
 	}
 
 	// Platform-specific copies. In CI copy everything so the smoke test can
@@ -265,6 +267,7 @@ func doInit(tools Tools, fsys fs.FS, force bool) ([]string, error) {
 		pairs = append(pairs,
 			struct{ src, dst string }{".opencode", ".opencode"},
 			struct{ src, dst string }{"AGENTS.md", "AGENTS.md"},
+			struct{ src, dst string }{"OPENCODE.md", "OPENCODE.md"},
 			struct{ src, dst string }{"opencode.json", "opencode.json"},
 		)
 	}
@@ -487,7 +490,11 @@ design:
   token_format: dtcg      # W3C DTCG
 
 github:
-  project_number: null
-  project_node_id: null
+  project_number: null    # null = ask once; 0 = declined; N = configured board (maple project bootstrap)
+  project_node_id: null    # Set by: maple project bootstrap
+  status_field_id: null    # Status single-select field id; cached by gh-projects / maple project bootstrap
+  milestone_granularity: null  # null = ask once; none = declined; minor = major+minor; patch = also per-patch
+  # Issue label taxonomy (type:bug | type:feature | type:docs | type:refactor | type:chore)
+  # lives in the gh-labels-milestones skill, not here. See "Version & Issue Tracking" in CLAUDE.md.
 `, name, time.Now().Format(time.RFC3339))
 }

--- a/tui/init.go
+++ b/tui/init.go
@@ -248,10 +248,14 @@ func doInit(tools Tools, fsys fs.FS, force bool) ([]string, error) {
 		{"Makefile", "Makefile"}, // skipped on first copy if already exists when force=false
 		{"lefthook.yml", "lefthook.yml"},
 		{".github", ".github"},
-		{"COPILOT.md", "COPILOT.md"},
 		{".gitignore", ".gitignore"},
 		{".cursor", ".cursor"},
+		// Root harness docs — always shipped. req.go points every agent at all four
+		// regardless of which harness is running, so all four must exist.
+		{"CLAUDE.md", "CLAUDE.md"},
+		{"OPENCODE.md", "OPENCODE.md"},
 		{"CURSOR.md", "CURSOR.md"},
+		{"COPILOT.md", "COPILOT.md"},
 	}
 
 	// Platform-specific copies. In CI copy everything so the smoke test can
@@ -260,14 +264,12 @@ func doInit(tools Tools, fsys fs.FS, force bool) ([]string, error) {
 	if tools.Claude != "" || ciMode {
 		pairs = append(pairs,
 			struct{ src, dst string }{".claude", ".claude"},
-			struct{ src, dst string }{"CLAUDE.md", "CLAUDE.md"},
 		)
 	}
 	if tools.OpenCode != "" || ciMode {
 		pairs = append(pairs,
 			struct{ src, dst string }{".opencode", ".opencode"},
 			struct{ src, dst string }{"AGENTS.md", "AGENTS.md"},
-			struct{ src, dst string }{"OPENCODE.md", "OPENCODE.md"},
 			struct{ src, dst string }{"opencode.json", "opencode.json"},
 		)
 	}

--- a/tui/init.go
+++ b/tui/init.go
@@ -471,7 +471,7 @@ func projectConfigYAML(name string) string {
   created_at: "%s"
 
 sdlc:
-  mode: standard          # standard | spike | quick
+  mode: standard          # standard | spike
   require_adr_for:
     - new_dependency
     - cross_boundary_change
@@ -481,13 +481,11 @@ sdlc:
     - visual_identity_change
 
 qa:
-  bdd: cucumber           # cucumber | behave | pytest-bdd
-  coverage_threshold: 80
+  bdd: cucumber           # cucumber | behave | none
 
 design:
   target: web             # web | tui — UI medium the design phase targets
-  ui_library: null        # mantine | tailwind | shadcn | null
-  token_format: dtcg      # W3C DTCG
+  ui_library: none        # mantine | tailwind | shadcn | none
 
 github:
   project_number: null    # null = ask once; 0 = declined; N = configured board (maple project bootstrap)


### PR DESCRIPTION
Closes #21.

Makes every change get a GitHub issue, a major/minor milestone, and a project card — driven by `project.config.yaml → github`, identically across Claude, OpenCode, Cursor, and Copilot. MAPLE port of Heimdall #131/#153 with every review finding pre-fixed, plus MAPLE's interactive ask-once/persist bootstrap.

## Changes
- **Config + schema** — `github` block gains `status_field_id` + `milestone_granularity`; schema widened so it validates (dropped the `labels` key — the `type:*` taxonomy lives in `gh-labels-milestones`). `null` = ask once; `0`/`none` = declined sentinels.
- **7 doc surfaces** — identical "Version & Issue Tracking (mandatory)" section in CLAUDE/OPENCODE/CURSOR/COPILOT/AGENTS + copilot-instructions + new `.cursor/rules/version-and-issues.mdc`.
- **Skills (×3 mirrors)** — `gh-projects` board gate + `status_field_id` cache (and a real config-parse bug fix); `gh-labels-milestones` granularity gate; `gh-issues` `type:*` labels + omit milestone when disabled.
- **Orchestrator agent (×3)** — subsection under the existing `## GitHub Issue Management`.
- **maple init** — generate the new config keys (config is Go-generated, not template-copied) and ship the `OPENCODE.md`/`CURSOR.md`/`COPILOT.md` root docs that were never installed.

## Correctness / compat
- `type:bug`/`type:feature` (not `bug`/`enhancement`); `In Progress` capital P (matches GitHub's default option — Heimdall's lowercase would no-op).
- Backwards compatible: no strict yaml decode; old configs without the new keys still validate and never crash the binary; string-replace bootstrap anchors intact.
- Verified: new/legacy/sentinel/configured configs validate; `make build-tui` green; fresh `maple init` produces the keys + all 7 rule surfaces; mirror copies byte-identical.

Spec: `docs/specs/2026-07-03-cross-harness-issue-tracking.md`.